### PR TITLE
Se desarrolló el CRUD de Makers

### DIFF
--- a/app/Http/Modules/Maker/Maker.php
+++ b/app/Http/Modules/Maker/Maker.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Modules\Maker;
+
+use App\Traits\SecureDeletes;
+use Illuminate\Database\Eloquent\Model;
+
+class Maker extends Model
+{
+    use SecureDeletes;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+}

--- a/app/Http/Modules/Maker/MakerController.php
+++ b/app/Http/Modules/Maker/MakerController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Modules\Maker;
+
+use App\Http\Controllers\Controller;
+use App\Http\Modules\Maker\Maker;
+
+class MakerController extends Controller
+{
+  /**
+   * Display a listing of the resource.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function index()
+  {
+    $makers = Maker::paginate();
+
+    return $this->showAll($makers);
+  }
+
+  /**
+   * Store a newly created resource in storage.
+   *
+   * @param  App\Http\Modules\Maker\MakerRequest  $request
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function store(MakerRequest $request)
+  {
+    $maker = Maker::create($request->validated());
+
+    return $this->showOne($maker, 201);
+  }
+
+  /**
+   * Display the specified resource.
+   *
+   * @param  App\Http\Modules\Maker\Maker  $maker
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function show(Maker $maker)
+  {
+    return $this->showOne($maker);
+  }
+
+  /**
+   * Update the specified resource in storage.
+   *
+   * @param  App\Http\Modules\Maker\MakerRequest  $request
+   * @param  App\Http\Modules\Maker\Maker  $maker
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function update(MakerRequest $request, Maker $maker)
+  {
+    $maker->update($request->validated());
+
+    return $this->showOne($maker);
+  }
+
+  /**
+   * Remove the specified resource from storage.
+   *
+   * @param  App\Http\Modules\Maker\Maker  $maker
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function destroy(Maker $maker)
+  {
+    $maker->secureDelete();
+
+    return $this->showOne($maker);
+  }
+}

--- a/app/Http/Modules/Maker/MakerRequest.php
+++ b/app/Http/Modules/Maker/MakerRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Modules\Maker;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class MakerRequest extends FormRequest
+{
+  /**
+   * Determine if the user is authorized to make this request.
+   *
+   * @return bool
+   */
+  public function authorize()
+  {
+    return true;
+  }
+
+  /**
+   * Get the validation rules that apply to the request.
+   *
+   * @return array
+   */
+  public function rules()
+  {
+    $rules = [
+      'name' => 'required|string|max:150|unique:makers',
+    ];
+
+    if ($this->isMethod('PUT')) {
+      $rules['name'] = "required|string|max:150|unique:makers,name,{$this->maker->name},name";
+    }
+
+    return $rules;
+  }
+  
+}

--- a/database/data/permissions.json
+++ b/database/data/permissions.json
@@ -73,5 +73,16 @@
 			{ "name": "Almacenar Usuarios",  "route_name": "users.store" },
 			{ "name": "Eliminar Usuarios",   "route_name": "users.destroy" }
 		]
+	},
+	{
+		"group": "Fabricantes",
+		"level": 1,
+		"labels": [
+			{ "name": "Listar Fabricantes",     "route_name": "makers.index" },
+			{ "name": "Actualizar Fabricantes", "route_name": "makers.update" },
+			{ "name": "Mostrar Fabricantes",    "route_name": "makers.show" },
+			{ "name": "Almacenar Fabricantes",  "route_name": "makers.store" },
+			{ "name": "Eliminar Fabricantes",   "route_name": "makers.destroy" }
+		]
 	}
 ]

--- a/database/factories/MakerFactory.php
+++ b/database/factories/MakerFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use Faker\Generator as Faker;
+use App\Http\Modules\Maker\Maker;
+
+$factory->define(Maker::class, function (Faker $faker) {
+
+    return [
+        'name' => $faker->unique()->company,
+    ];
+});

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -18,6 +18,7 @@ class DatabaseSeeder extends Seeder
             CountrySeeder::class,
             CompanySeeder::class,
             UserSeeder::class,
+            MakerSeeder::class,
         ]);
     }
 }

--- a/database/seeds/MakerSeeder.php
+++ b/database/seeds/MakerSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Http\Modules\Maker\Maker;
+use Illuminate\Database\Seeder;
+
+class MakerSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        factory(Maker::class, 2)->create();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,6 +33,8 @@ Route::group(['middleware' => ['auth', 'access']], function () {
 
     Route::resource('users', 'User\UserController')->except('create', 'edit');
 
+    Route::resource('makers', 'Maker\MakerController')->except('create', 'edit');
+
 });
 
 /***********************************************************************************************************************

--- a/tests/Feature/MakerControllerTest.php
+++ b/tests/Feature/MakerControllerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\ApiTestCase;
+use App\Http\Modules\Maker\Maker;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+class MakerControllerTest extends ApiTestCase
+{
+  use DatabaseMigrations, RefreshDatabase;
+
+  public function setUp(): void
+  {
+    parent::setUp();
+
+    $this->seed(['PermissionSeeder', 'RoleSeeder', 'UserSeeder', 'MakerSeeder']);
+  }
+
+  /**
+   * @test
+   */
+  public function a_guest_cannot_access_to_maker_resources()
+  {
+    $this->getJson(route('makers.index'))->assertUnauthorized();
+    $this->getJson(route('makers.show', rand()))->assertUnauthorized();
+    $this->postJson(route('makers.store'))->assertUnauthorized();
+    $this->putJson(route('makers.update', rand()))->assertUnauthorized();
+    $this->deleteJson(route('makers.destroy', rand()))->assertUnauthorized();
+  }
+
+  /**
+   * @test
+   */
+  public function an_user_without_permission_cannot_access_to_maker_resources()
+  {
+    $this->signIn();
+    
+    $randomMakerId = Maker::all()->random()->id;
+
+    $this->getJson(route('makers.index'))->assertForbidden();
+    $this->getJson(route('makers.show', $randomMakerId))->assertForbidden();
+    $this->postJson(route('makers.store'))->assertForbidden();
+    $this->putJson(route('makers.update', $randomMakerId))->assertForbidden();
+    $this->deleteJson(route('makers.destroy', $randomMakerId))->assertForbidden();
+  }
+
+  /**
+   * @test
+   */
+  public function an_user_with_role_with_permission_can_see_all_makers()
+  {
+
+    $role = $this->getRoleWithPermissionsTo(['makers.index']);
+    $user = $this->signInWithRole($role);
+
+    $response = $this->getJson(route('makers.index'))
+      ->assertOk();
+    
+    foreach (Maker::limit(10)->get() as $maker) {
+      $response->assertJsonFragment($maker->toArray());
+    }
+  }
+
+  /**
+   * @test
+   */
+  public function an_user_with_role_with_permission_can_see_a_maker()
+  {
+    $role = $this->getRoleWithPermissionsTo(['makers.show']);
+    $user = $this->signInWithRole($role);
+
+    $maker = factory(Maker::class)->create();
+
+    $this->getJson(route('makers.show', $maker->id))
+      ->assertOk()
+      ->assertJson($maker->toArray());
+  }
+
+  /**
+   * @test
+   */
+  public function an_user_with_role_with_permission_can_store_a_maker()
+  {
+    $role = $this->getRoleWithPermissionsTo(['makers.store']);
+    $user = $this->signInWithRole($role);
+
+    $attributes = factory(Maker::class)->raw();
+
+    $this->postJson(route('makers.store'), $attributes)
+      ->assertCreated();
+    
+    $this->assertDatabaseHas('makers', $attributes);
+  }
+
+
+  /**
+   * @test
+   */
+  public function an_user_with_role_with_permission_can_update_a_maker()
+  {
+    $this->withExceptionHandling();
+
+    $role = $this->getRoleWithPermissionsTo(['makers.update']);
+    $user = $this->signInWithRole($role);
+
+    $maker = factory(Maker::class)->create();
+
+    $attributes = factory(Maker::class)->raw();
+
+    $this->putJson(route('makers.update', $maker->id), $attributes)
+      ->assertOk();
+
+    $this->assertDatabaseHas('makers', $attributes);
+  }
+
+  /**
+   * @test
+   */
+  public function an_user_with_role_with_permission_can_destroy_a_maker()
+  {
+    $role = $this->getRoleWithPermissionsTo(['makers.destroy']);
+    $user = $this->signInWithRole($role);
+
+    $maker = factory(Maker::class)->create();
+
+    $this->deleteJson(route('makers.destroy', $maker->id))
+      ->assertOk();
+
+    $this->assertDatabaseMissing('makers', $maker->toArray());
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
[CRUD Maker](https://app.asana.com/0/1177709353800153/1182695000809147/f)
- [x] QA @
- [ ] CR @

## What changed?
Se desarrolló el CRUD de Maker.

## Test plan
- Unit Testing: `phpunit --filter MakerControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene la carpeta Maker, en la cual se encuentran las peticiones para probar dicho módulo.