### PR TITLE
Se desarrolló el servicio para listar todos los items para la venta e…

### DIFF
--- a/app/Http/Modules/Sell/StoreTurnItemController.php
+++ b/app/Http/Modules/Sell/StoreTurnItemController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Modules\Sell;
+
+use Illuminate\Http\Request;
+use App\Http\Modules\Turn\Turn;
+use App\Http\Modules\Store\Store;
+use Illuminate\Support\Facades\DB;
+use App\Http\Controllers\Controller;
+use App\Http\Modules\StoreTurn\StoreTurn;
+use Illuminate\Database\Query\JoinClause;
+use App\Http\Modules\Presentation\Presentation;
+use App\Http\Modules\PresentationCombo\PresentationCombo;
+
+class StoreTurnItemController extends Controller
+{
+  /**
+   * Display a listing of the resource.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function index(Request $request, Store $store, Turn $turn)
+  {
+    $storeTurn = StoreTurn::where('store_id', $store->id)
+      ->where('turn_id', $turn->id)
+      ->where('is_open', true)
+      ->firstOrFail();
+
+    $presentationsQuery = Presentation::select('id', 'description')
+      ->selectRaw("COALESCE (tp.price, presentations.price) AS price, 'PRESENTATION' AS type")
+      ->leftJoin('turns_products AS tp', function (JoinClause $leftJoin) use ($storeTurn) {
+        $leftJoin->on('presentations.id', '=', 'tp.presentation_id')
+          ->where('tp.turn_id', $storeTurn->turn_id);
+      });
+
+    $combosQuery = PresentationCombo::select('presentation_combos.id', 'description')
+      ->selectRaw("COALESCE (tc.suggested_price, presentation_combos.suggested_price) AS price, 'COMBO' AS type")
+      ->leftJoin('presentation_combos_stores_turns AS tc', function (JoinClause $leftJoin) use ($storeTurn) {
+        $leftJoin->on('presentation_combos.id', '=', 'tc.presentation_combo_id')
+          ->where('tc.turn_id', $storeTurn->turn_id);
+      });
+
+    $items = DB::query()
+      ->fromSub($presentationsQuery->union($combosQuery), 'items')
+      ->orderBy('description');
+    
+    return $this->showAll($items, ['id', 'description', 'type']);
+  }
+}

--- a/database/data/permissions_groups.json
+++ b/database/data/permissions_groups.json
@@ -343,7 +343,7 @@
       {
         "name": "Ver Registro de Ventas",
         "level": 4,
-        "routes": ["sells.index", "sells.show", "stocks.index"]
+        "routes": ["sells.index", "sells.show", "stocks.index", "stores.turns.items.index"]
       },
       {
         "name": "Crear Registro de Ventas",

--- a/routes/api.php
+++ b/routes/api.php
@@ -107,6 +107,8 @@ Route::group(['middleware' => ['auth', 'access']], function () {
     
     Route::resource('store-turns', 'StoreTurn\StoreTurnController')->except('create', 'edit');
 
+    Route::resource('stores.turns.items', 'Sell\StoreTurnItemController')->only('index');
+
 });
 
 /***********************************************************************************************************************

--- a/tests/Feature/StoreTurnItemControllerTest.php
+++ b/tests/Feature/StoreTurnItemControllerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\ApiTestCase;
+use App\Http\Modules\Turn\Turn;
+use App\Http\Modules\StoreTurn\StoreTurn;
+use App\Http\Modules\Presentation\Presentation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Http\Modules\PresentationCombo\PresentationCombo;
+
+class StoreTurnItemControllerTest extends ApiTestCase
+{
+  use RefreshDatabase;
+
+  public function setUp(): void
+  {
+    parent::setUp();
+
+    $this->seed(['PermissionSeeder', 'TurnSeeder', 'PresentationSeeder', 'PresentationComboSeeder']);
+  }
+
+  /**
+   * @test
+   */
+  public function a_guest_cannot_access_to_store_turn_item_resources()
+  {
+    $turn = Turn::inRandomOrder()->first();
+
+    $this->getJson(route('stores.turns.items.index', [$turn->store_id, $turn->id]))->assertUnauthorized();
+  }
+
+  /**
+   * @test
+   */
+  public function an_user_without_permission_cannot_access_to_store_turn_item_resources()
+  {
+    $this->signIn();
+
+    $turn = Turn::inRandomOrder()->first();
+    
+    $this->getJson(route('stores.turns.items.index', [$turn->store_id, $turn->id]))->assertForbidden();
+  }
+
+  /**
+   * @test
+   */
+  public function an_user_with_permission_can_see_all_store_turn_items()
+  {
+    $this->signInWithPermissionsTo(['stores.turns.items.index']);
+
+    $storeTurn = factory(StoreTurn::class)->create(['is_open' => true]);
+
+    $response = $this->getJson(route('stores.turns.items.index', [$storeTurn->store_id, $storeTurn->turn_id]))
+      ->assertOk();
+
+    $presentation = Presentation::limit(5)->get();
+    $combos = PresentationCombo::limit(5)->get(['id', 'description', 'suggested_price AS price']);
+
+    $items = $presentation->merge($combos);
+
+    $items->each(function ($item) use ($response) {
+      $response->assertJsonFragment([
+        'id'          => "$item->id",
+        'description' => $item->description,
+        'price'       => $item->price,
+        'type'        => $item instanceof Presentation ? 'PRESENTATION' : 'COMBO',
+      ]);
+    });
+  }
+}


### PR DESCRIPTION
## Pull Request Description
[List Items to Sell](https://app.asana.com/0/1177709353800153/1190687686656803/f)
- [x] QA @
- [x] CR @

## What changed?
Se desarrolló el servicio para listar todos los items (Presentaciones y Combos) para la venta con los precios del turno.

## Test plan
- Unit Testing: `phpunit --filter StoreTurnItemControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene la carpeta StoreTurnItem, en la cual se encuentra la petición para probar dicho servicio.