### PR TITLE
Se convirtió la lista de objetos de permisos en una lista de id's

### DIFF
--- a/app/Http/Modules/User/AuthController.php
+++ b/app/Http/Modules/User/AuthController.php
@@ -141,21 +141,9 @@ class AuthController extends Controller
      */
     public function me()
     {
-        $user = auth()->user();
+        $user = clone(auth()->user());
 
-        $user->getDirectPermissions()
-            ->map(function (Permission $permission) {
-                $permission->name = explode(' ', $permission->name)[0];
-
-                $permission->makeHidden([
-                    'guard_name',
-                    'created_at',
-                    'updated_at',
-                    'pivot',
-                ]);
-
-                return $permission;
-            });
+        $user->permissions = auth()->user()->getDirectPermissions()->pluck('id');
 
         return $this->showOne($user);
     }


### PR DESCRIPTION
## Pull Request Description
[Auth](https://app.asana.com/0/1177709353800153/1182046582312288/f)
- [x] QA @
- [ ] CR @

## What changed?
- Se convirtió la lista de objetos de permisos en una lista de id's

## Test plan
- Unit Testing: `phpunit --filter AuthControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene la carpeta Auth, en la cual se encuentra la petición "me" para probar dicho cambio.