### PR TITLE
Se cambiaron los atributos de Productos y Presentaciones

### DIFF
--- a/app/Http/Modules/Presentation/Presentation.php
+++ b/app/Http/Modules/Presentation/Presentation.php
@@ -21,7 +21,7 @@ class Presentation extends Model
         'product_id',
         'description',
         'price',
-        'is_minimal_expression',
+        'is_grouping',
         'units',
     ];
 

--- a/app/Http/Modules/Presentation/PresentationRequest.php
+++ b/app/Http/Modules/Presentation/PresentationRequest.php
@@ -27,8 +27,7 @@ class PresentationRequest extends FormRequest
     $rules = [
       'product_id'            => 'required|exists:products,id',
       'price'                 => 'required|integer|min:0',
-      'is_minimal_expression' => 'required|boolean',
-      'units'                 => 'required|numeric|min:0',
+      'is_grouping'           => 'required|boolean',
       'description'           => [
         'required', 
         'string',
@@ -39,6 +38,10 @@ class PresentationRequest extends FormRequest
           }),
       ], 
     ];
+
+    if ($this->get('is_grouping')) {
+      $rules['units'] = 'required|numeric|min:2';
+    }
 
     if ($this->isMethod('PUT')) {
       $rules['description'] = [
@@ -54,5 +57,21 @@ class PresentationRequest extends FormRequest
     }
 
     return $rules;
+  }
+
+  /**
+   * Get the validated data from the request.
+   *
+   * @return array
+   */
+  public function validated()
+  {
+    $validatedData = parent::validated();
+
+    if ( ! $validatedData['is_grouping'] ) {
+      $validatedData['units'] = 1;
+    }
+
+    return $validatedData;
   }
 }

--- a/app/Http/Modules/Product/Product.php
+++ b/app/Http/Modules/Product/Product.php
@@ -32,7 +32,6 @@ class Product extends Model
         'is_taxable',
         'is_inventoriable',
         'uom_id',
-        'minimal_expresion',
         'suggested_price',
     ];
 

--- a/app/Http/Modules/Product/ProductController.php
+++ b/app/Http/Modules/Product/ProductController.php
@@ -6,8 +6,9 @@ use Exception;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
-use Illuminate\Support\Facades\Schema;
 use App\Http\Modules\Product\Product;
+use Illuminate\Support\Facades\Schema;
+use App\Http\Modules\Presentation\Presentation;
 
 class ProductController extends Controller
 {
@@ -24,6 +25,14 @@ class ProductController extends Controller
 
             $product = Product::create($request->validated());
             $product->productCountries()->sync($request->countries);
+
+            Presentation::create([
+                'product_id'            => $product->id,
+                'price'                 => $product->suggested_price,
+                'is_grouping'           => false,
+                'units'                 => 1,
+                'description'           => $product->description
+            ]);
 
             DB::commit();
             return $this->showOne($product, 201);

--- a/app/Http/Modules/Product/ProductRequest.php
+++ b/app/Http/Modules/Product/ProductRequest.php
@@ -32,7 +32,6 @@ class ProductRequest extends FormRequest
             'is_taxable'             => 'required|boolean',
             'is_inventoriable'       => 'required|boolean',
             'uom_id'                 => 'required|exists:uoms,id',
-            'minimal_expresion'      => 'required|string',
             'suggested_price'        => 'required|numeric|min:0',
             'countries'              => 'required|array',
             'countries.*'            => 'exists:countries,id',

--- a/database/factories/PresentationFactory.php
+++ b/database/factories/PresentationFactory.php
@@ -7,11 +7,16 @@ use App\Http\Modules\Presentation\Presentation;
 use Faker\Generator as Faker;
 
 $factory->define(Presentation::class, function (Faker $faker) {
+
+    $isGrouping = rand(0, 1);
+
+    $units = $isGrouping ? rand(2, 10) : 1;
+
     return [
         'description'           => $faker->unique()->sentence,
         'price'                 => rand(1, 20) * 100,
         'product_id'            => factory(Product::class),
-        'is_minimal_expression' => rand(0, 1),
-        'units'                 => rand(1, 10),
+        'is_grouping'           => $isGrouping,
+        'units'                 => $units,
     ];
 });

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -19,7 +19,6 @@ $factory->define(Product::class, function (Faker $faker) {
         'is_taxable'             => rand(0, 1),
         'is_inventoriable'       => rand(0, 1),
         'uom_id'                 => Uom::inRandomOrder()->first() ?? factory(Uom::class),
-        'minimal_expresion'      => $faker->unique()->company,
         'suggested_price'        => rand(1, 10) * 100,
         'is_all_countries'       => rand(0, 1),
     ];

--- a/database/migrations/2020_06_27_000021_create_products_table.php
+++ b/database/migrations/2020_06_27_000021_create_products_table.php
@@ -30,7 +30,6 @@ class CreateProductsTable extends Migration
             $table->tinyInteger('is_taxable');
             $table->tinyInteger('is_inventoriable');
             $table->unsignedBigInteger('uom_id');
-            $table->string('minimal_expresion');
             $table->double('suggested_price');
             $table->timestamps();
             $table->softDeletes();

--- a/database/migrations/2020_06_27_000022_create_presentations_table.php
+++ b/database/migrations/2020_06_27_000022_create_presentations_table.php
@@ -25,7 +25,7 @@ class CreatePresentationsTable extends Migration
             $table->unsignedBigInteger('product_id');
             $table->string('description');
             $table->double('price');
-            $table->tinyInteger('is_minimal_expression');
+            $table->tinyInteger('is_grouping');
             $table->float('units');
             $table->timestamps();
             $table->softDeletes();


### PR DESCRIPTION
## Pull Request Description
[Product and Presentation creation](https://app.asana.com/0/1177709353800153/1199408281020182/f)
- [x] QA @
- [x] CR @

## What changed?
- Se cambió el atributo is_minimal_expression por is_grouping en las Presentaciones
- Se eliminó el atributo minimal_expression en los Productos
- Al crear un Producto se crea automáticamente su primera Presentación con 1 unidad y los mismos datos
- Al crear una Presentación con is_grouping = false, la unidades de dicha Presentación se vuelven 1

## Test plan
- Unit Testing: `phpunit --filter ProductControllerTest`
- Unit Testing: `phpunit --filter PresentationControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene las carpetas Product y Presentation, en las cuales se encuentran las peticiones para los cambios mencionados.