### PR TITLE
Se omiten los recursos por id al actualizar sus propios datos

### DIFF
--- a/app/Http/Modules/Company/CompanyRequest.php
+++ b/app/Http/Modules/Company/CompanyRequest.php
@@ -47,7 +47,7 @@ class CompanyRequest extends FormRequest
 
     if ($this->isMethod('PUT')) {
 
-      $rules['phone'] = "required|digits_between:1,50|unique:companies,phone,{$this->company->phone},phone";
+      $rules['phone'] = "required|digits_between:1,50|unique:companies,phone,{$this->company->id}";
 
       $rules['nit'] = [
         'required', 

--- a/app/Http/Modules/Country/CountryRequest.php
+++ b/app/Http/Modules/Country/CountryRequest.php
@@ -29,7 +29,7 @@ class CountryRequest extends FormRequest
     ];
 
     if ($this->isMethod('PUT')) {
-      $rules['name'] = "required|string|max:150|unique:countries,name,\"{$this->country->name}\",name";
+      $rules['name'] = "required|string|max:150|unique:countries,name,{$this->country->id}";
     }
 
     return $rules;

--- a/app/Http/Modules/Currency/CurrencyRequest.php
+++ b/app/Http/Modules/Currency/CurrencyRequest.php
@@ -32,8 +32,8 @@ class CurrencyRequest extends FormRequest
     ];
 
     if ($this->isMethod('PUT')) {
-      $rules['name']         = "required|string|max:255|unique:currencies,name,\"{$this->currency->name}\",name";
-      $rules['abbreviation'] = "required|string|max:16|unique:currencies,abbreviation,\"{$this->currency->abbreviation}\",abbreviation";
+      $rules['name']         = "required|string|max:255|unique:currencies,name,{$this->currency->id}";
+      $rules['abbreviation'] = "required|string|max:16|unique:currencies,abbreviation,{$this->currency->id}";
     }
 
     return $rules;

--- a/app/Http/Modules/Deposit/DepositRequest.php
+++ b/app/Http/Modules/Deposit/DepositRequest.php
@@ -43,7 +43,7 @@ class DepositRequest extends FormRequest
     ];
 
     if ($this->isMethod('PUT')) {
-      $rules['deposit_number'] = "required|string|max:100|unique:deposits,deposit_number,{$this->deposit->id},id";
+      $rules['deposit_number'] = "required|string|max:100|unique:deposits,deposit_number,{$this->deposit->id}";
     }
 
     return $rules;

--- a/app/Http/Modules/LocationType/LocationTypeRequest.php
+++ b/app/Http/Modules/LocationType/LocationTypeRequest.php
@@ -28,7 +28,7 @@ class LocationTypeRequest extends FormRequest
     ];
 
     if ($this->isMethod('PUT')) {
-      $rules['name'] = "required|string|max:150|unique:location_types,name,\"{$this->location_type->name}\",name";
+      $rules['name'] = "required|string|max:150|unique:location_types,name,{$this->location_type->id}";
     }
 
     return $rules;

--- a/app/Http/Modules/Maker/MakerRequest.php
+++ b/app/Http/Modules/Maker/MakerRequest.php
@@ -28,7 +28,7 @@ class MakerRequest extends FormRequest
     ];
 
     if ($this->isMethod('PUT')) {
-      $rules['name'] = "required|string|max:150|unique:makers,name,\"{$this->maker->name}\",name";
+      $rules['name'] = "required|string|max:150|unique:makers,name,{$this->maker->id}";
     }
 
     return $rules;

--- a/app/Http/Modules/PresentationCombo/PresentationComboRequest.php
+++ b/app/Http/Modules/PresentationCombo/PresentationComboRequest.php
@@ -39,7 +39,7 @@ class PresentationComboRequest extends FormRequest
     ];
 
     if ($this->isMethod('PUT')) {
-      $rules['description'] = "required|string|max:150|unique:presentation_combos,description,\"{$this->presentation_combo->description}\",description";
+      $rules['description'] = "required|string|max:150|unique:presentation_combos,description,{$this->presentation_combo->id}";
     }
 
     return $rules;

--- a/app/Http/Modules/PresentationSku/PresentationSkuRequest.php
+++ b/app/Http/Modules/PresentationSku/PresentationSkuRequest.php
@@ -32,7 +32,7 @@ class PresentationSkuRequest extends FormRequest
     ];
 
     if ($this->isMethod('PUT')) {
-      $rules['code'] = "required|string|max:150|unique:presentation_skus,code,\"{$this->presentation_sku->code}\",code";
+      $rules['code'] = "required|string|max:150|unique:presentation_skus,code,{$this->presentation_sku->id}";
     }
 
     return $rules;

--- a/app/Http/Modules/Product/ProductRequest.php
+++ b/app/Http/Modules/Product/ProductRequest.php
@@ -38,7 +38,7 @@ class ProductRequest extends FormRequest
         ];
 
         if ($this->isMethod('PUT')) {
-            $rules['description'] = "string|max:255|unique:products,description,\"{$this->product->description}\",description";
+            $rules['description'] = "string|max:255|unique:products,description,{$this->product->id}";
         }
 
         return $rules;

--- a/app/Http/Modules/ProductCategory/ProductCategoryRequest.php
+++ b/app/Http/Modules/ProductCategory/ProductCategoryRequest.php
@@ -29,7 +29,7 @@ class ProductCategoryRequest extends FormRequest
     ];
 
     if ($this->isMethod('PUT')) {
-      $rules['name'] = "required|string|max:255|unique:product_categories,name,\"{$this->product_category->name}\",name";
+      $rules['name'] = "required|string|max:255|unique:product_categories,name,{$this->product_category->id}";
       $rules['product_department_id'] = "exists:product_departments,id";
     }
 

--- a/app/Http/Modules/ProductDepartment/ProductDepartmentRequest.php
+++ b/app/Http/Modules/ProductDepartment/ProductDepartmentRequest.php
@@ -28,7 +28,7 @@ class ProductDepartmentRequest extends FormRequest
     ];
 
     if ($this->isMethod('PUT')) {
-      $rules['name'] = "required|string|max:255|unique:product_departments,name,\"{$this->product_department->name}\",name";
+      $rules['name'] = "required|string|max:255|unique:product_departments,name,{$this->product_department->id}";
     }
 
     return $rules;

--- a/app/Http/Modules/SocioeconomicLevel/SocioeconomicLevelRequest.php
+++ b/app/Http/Modules/SocioeconomicLevel/SocioeconomicLevelRequest.php
@@ -31,7 +31,7 @@ class SocioeconomicLevelRequest extends FormRequest
     ];
 
     if ($this->isMethod('PUT')) {
-      $rules['name'] = "required|string|max:150|unique:socioeconomic_levels,name,\"{$this->socioeconomic_level->name}\",name";
+      $rules['name'] = "required|string|max:150|unique:socioeconomic_levels,name,{$this->socioeconomic_level->id}";
     }
 
     return $rules;

--- a/app/Http/Modules/StoreChain/StoreChainRequest.php
+++ b/app/Http/Modules/StoreChain/StoreChainRequest.php
@@ -28,7 +28,7 @@ class StoreChainRequest extends FormRequest
     ];
 
     if ($this->isMethod('PUT')) {
-      $rules['name'] = "required|string|max:150|unique:store_chains,name,\"{$this->store_chain->name}\",name";
+      $rules['name'] = "required|string|max:150|unique:store_chains,name,{$this->store_chain->id}";
     }
 
     return $rules;

--- a/app/Http/Modules/StoreFormat/StoreFormatRequest.php
+++ b/app/Http/Modules/StoreFormat/StoreFormatRequest.php
@@ -28,7 +28,7 @@ class StoreFormatRequest extends FormRequest
     ];
 
     if ($this->isMethod('PUT')) {
-      $rules['name'] = "required|string|max:150|unique:store_formats,name,\"{$this->store_format->name}\",name";
+      $rules['name'] = "required|string|max:150|unique:store_formats,name,{$this->store_format->id}";
     }
 
     return $rules;

--- a/app/Http/Modules/StoreType/StoreTypeRequest.php
+++ b/app/Http/Modules/StoreType/StoreTypeRequest.php
@@ -28,7 +28,7 @@ class StoreTypeRequest extends FormRequest
     ];
 
     if ($this->isMethod('PUT')) {
-      $rules['name'] = "required|string|max:150|unique:store_types,name,\"{$this->store_type->name}\",name";
+      $rules['name'] = "required|string|max:150|unique:store_types,name,{$this->store_type->id}";
     }
 
     return $rules;

--- a/app/Http/Modules/Uom/UomRequest.php
+++ b/app/Http/Modules/Uom/UomRequest.php
@@ -30,8 +30,8 @@ class UomRequest extends FormRequest
     ];
 
     if ($this->isMethod('PUT')) {
-      $rules['name'] = "required|string|max:255|unique:uoms,name,\"{$this->uom->name}\",name";
-      $rules['abbreviation'] = "required|string|max:16|unique:uoms,abbreviation,\"{$this->uom->abbreviation}\",abbreviation";
+      $rules['name'] = "required|string|max:255|unique:uoms,name,{$this->uom->id}";
+      $rules['abbreviation'] = "required|string|max:16|unique:uoms,abbreviation,{$this->uom->id}";
     }
 
     return $rules;


### PR DESCRIPTION
## Pull Request Description
[Update Resources](https://app.asana.com/0/1177709353800153/1198205785347685/f)
- [x] QA @
- [ ] CR @

## What changed?
- Al actualizar un recurso se omiten las validaciones por su id para mantener sus propios datos


## Test plan
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) se encuentran las peticiones para probar el cambioa mencionado.