### PR TITLE
Ss/save email and phone on clients

### DIFF
--- a/app/Http/Modules/Client/ClientRequest.php
+++ b/app/Http/Modules/Client/ClientRequest.php
@@ -33,6 +33,8 @@ class ClientRequest extends FormRequest
       'sex'          => 'required|in:'.implode(',', Client::getOptionsSex()),
       'biometric_id' => 'sometimes|nullable|string|max:1000',
       'birthdate'    => 'required|date|date_format:Y-m-d|before:today|after:1900-01-01',
+      'phone'        => 'present|nullable|max:50',
+      'email'        => 'present|nullable|email|max:100',
       'nit'          => [
         'required', 
         'digits_between:1,15',

--- a/app/Http/Modules/Sell/SellRequest.php
+++ b/app/Http/Modules/Sell/SellRequest.php
@@ -33,7 +33,7 @@ class SellRequest extends FormRequest
       'nit'                => 'required|digits_between:1,15',
       'address'            => 'sometimes|nullable|string|max:50',
       'phone'              => 'required|string|max:50',
-      'email'              => 'required|string|email',
+      'email'              => 'required|string|email|max:100',
       'description'        => 'sometimes|nullable|string|max:250',
       'items'              => 'required|array',
       'items.*.quantity'   => 'required|numeric|min:0',

--- a/tests/Feature/ClientControllerTest.php
+++ b/tests/Feature/ClientControllerTest.php
@@ -79,11 +79,16 @@ class ClientControllerTest extends ApiTestCase
    */
   public function an_user_with_permission_can_store_a_client()
   {
-    $this->signInWithPermissionsTo(['clients.store']);
+    $user = $this->signInWithPermissionsTo(['clients.store']);
 
     $attributes = factory(Client::class)->raw();
 
-    $this->postJson(route('clients.store'), $attributes)
+    $extraAttributes = [
+      'phone' => $user->phone,
+      'email' => $user->email,
+    ];
+
+    $this->postJson(route('clients.store'), array_merge($attributes, $extraAttributes))
       ->assertCreated();
     
     $this->assertDatabaseHas('clients', $attributes);
@@ -95,13 +100,18 @@ class ClientControllerTest extends ApiTestCase
    */
   public function an_user_with_permission_can_update_a_client()
   {
-    $this->signInWithPermissionsTo(['clients.update']);
+    $user = $this->signInWithPermissionsTo(['clients.update']);
 
     $client = factory(Client::class)->create();
 
     $attributes = factory(Client::class)->raw();
 
-    $this->putJson(route('clients.update', $client->id), $attributes)
+    $extraAttributes = [
+      'phone' => $user->phone,
+      'email' => $user->email,
+    ];
+
+    $this->putJson(route('clients.update', $client->id), array_merge($attributes, $extraAttributes))
       ->assertOk();
 
     $this->assertDatabaseHas('clients', $attributes);

--- a/tests/Feature/ClientControllerTest.php
+++ b/tests/Feature/ClientControllerTest.php
@@ -92,6 +92,10 @@ class ClientControllerTest extends ApiTestCase
       ->assertCreated();
     
     $this->assertDatabaseHas('clients', $attributes);
+
+    $this->assertDatabaseHas('company_clients', array_merge([
+      'company_id' => $user->company_id
+    ], $extraAttributes));
   }
 
 
@@ -104,6 +108,13 @@ class ClientControllerTest extends ApiTestCase
 
     $client = factory(Client::class)->create();
 
+    $client->companies()->syncWithoutDetaching([
+      $user->company_id => [
+        'email' => '',
+        'phone' => '',
+      ]
+    ]);
+
     $attributes = factory(Client::class)->raw();
 
     $extraAttributes = [
@@ -115,6 +126,11 @@ class ClientControllerTest extends ApiTestCase
       ->assertOk();
 
     $this->assertDatabaseHas('clients', $attributes);
+
+    $this->assertDatabaseHas('company_clients', array_merge([
+      'client_id' => $client->id,
+      'company_id' => $user->company_id
+    ], $extraAttributes));
   }
 
   /**


### PR DESCRIPTION
## Pull Request Description
[Clients Email and Phone](https://app.asana.com/0/1177709353800153/1199506021694612/f)
- [x] QA @
- [ ] CR @

## What changed?
- Al solicitar la creación o actualización de un cliente es obligatorio que los campos 'email' y 'phone' estén presentes en el payload, independientemente de si estos datos están vacíos o no.
- Se guarda el email y teléfono del cliente en la creación y actualización del mismo, basándose en la empresa del usuario logueado que ejecuta la acción.
- Al listar o solicitar los datos de los clientes se muestra la información de la empresa del usuario logueado así como los datos de email y teléfono recopilados por esta.

## Test plan
- Unit Testing: `phpunit --filter ClientControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene la carpeta Client, en la cual se encuentran las peticiones para probar los cambios mencionados.