### PR TITLE
Se desarrollaron listas de opciones para evitar conflictos con los permisos

### DIFF
--- a/app/Http/Modules/Brand/BrandController.php
+++ b/app/Http/Modules/Brand/BrandController.php
@@ -70,4 +70,18 @@ class BrandController extends Controller
 
     return $this->showOne($brand);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $brands = Brand::select('id', 'name')
+      ->withOut('maker');
+
+    return $this->showAll($brands, Schema::getColumnListing((new Brand)->getTable()));
+  }
+
 }

--- a/app/Http/Modules/Company/Company.php
+++ b/app/Http/Modules/Company/Company.php
@@ -4,6 +4,7 @@ namespace App\Http\Modules\Company;
 
 use App\Traits\SecureDeletes;
 use App\Http\Modules\User\User;
+use App\Http\Modules\Store\Store;
 use App\Http\Modules\Client\Client;
 use App\Http\Modules\Country\Country;
 use App\Http\Modules\Currency\Currency;
@@ -90,6 +91,16 @@ class Company extends Model
     public function clients()
     {
         return $this->belongsToMany(Client::class, 'company_clients')->withPivot('email', 'phone')->withTimestamps();
+    }
+
+    /**
+     * Get the stores for the Company.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function stores()
+    {
+        return $this->hasMany(Store::class);
     }
 
     /**

--- a/app/Http/Modules/LocationType/LocationTypeController.php
+++ b/app/Http/Modules/LocationType/LocationTypeController.php
@@ -70,4 +70,16 @@ class LocationTypeController extends Controller
 
     return $this->showOne($locationType);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $locationTypes = LocationType::select('id', 'name');
+
+    return $this->showAll($locationTypes, Schema::getColumnListing((new LocationType)->getTable()));
+  }
 }

--- a/app/Http/Modules/Maker/MakerController.php
+++ b/app/Http/Modules/Maker/MakerController.php
@@ -70,4 +70,16 @@ class MakerController extends Controller
 
     return $this->showOne($maker);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $makers = Maker::select('id', 'name');
+
+    return $this->showAll($makers, Schema::getColumnListing((new Maker)->getTable()));
+  }
 }

--- a/app/Http/Modules/Municipality/MunicipalityController.php
+++ b/app/Http/Modules/Municipality/MunicipalityController.php
@@ -70,4 +70,17 @@ class MunicipalityController extends Controller
 
     return $this->showOne($municipality);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $municipalities = Municipality::select('id', 'name')
+      ->withOut('state');
+
+    return $this->showAll($municipalities, Schema::getColumnListing((new Municipality)->getTable()));
+  }
 }

--- a/app/Http/Modules/PaymentMethod/PaymentMethodRequest.php
+++ b/app/Http/Modules/PaymentMethod/PaymentMethodRequest.php
@@ -52,5 +52,20 @@ class PaymentMethodRequest extends FormRequest
 
     return $rules;
   }
-  
+
+  /**
+   * Get the validated data from the request.
+   *
+   * @return array
+   */
+  public function validated()
+  {
+    $validatedData = parent::validated();
+
+    if (auth()->user()->role->level > 1) {
+      $validatedData['company_id'] = auth()->user()->company_id;
+    }
+
+    return $validatedData;
+  }
 }

--- a/app/Http/Modules/PresentationCombo/PresentationComboRequest.php
+++ b/app/Http/Modules/PresentationCombo/PresentationComboRequest.php
@@ -2,7 +2,8 @@
 
 namespace App\Http\Modules\PresentationCombo;
 
-use Illuminate\Validation\Rule;
+use App\Http\Modules\Turn\Turn;
+use App\Http\Modules\Store\Store;
 use Illuminate\Foundation\Http\FormRequest;
 
 class PresentationComboRequest extends FormRequest
@@ -33,10 +34,42 @@ class PresentationComboRequest extends FormRequest
       'presentations.*'          => 'exists:presentations,id',
       'prices'                   => 'required|array',
       'prices.*.suggested_price' => 'required|numeric|min:0',
-      'prices.*.store_id'        => 'required|exists:stores,id',
       'prices.*.turns'           => 'required|array',
-      'prices.*.turns.*'         => 'exists:turns,id',
     ];
+
+    foreach($this->get('prices', []) as $indexPrice => $price) {
+
+      $rules["prices.$indexPrice.store_id"] = [
+        'required',
+        'integer',
+        function ($attribute, $value, $fail) {
+          $store = Store::where('id', $value)
+            ->visible(auth()->user())
+            ->first();
+  
+          if (!$store) {
+            $fail("El campo {$attribute} {$value} es inválido.");
+          }
+        },
+      ];
+
+      foreach($price['turns'] ?? [] as $indexTurn => $turn_id) {
+
+        $rules["prices.$indexPrice.turns.$indexTurn"] = [
+          'integer',
+          function ($attribute, $value, $fail) use ($price, $turn_id) {
+            $turn = Turn::where('id', $value)
+              ->where('store_id', $price['store_id'] ?? -1)
+              ->visible(auth()->user())
+              ->first();
+
+            if (!$turn) {
+              $fail("El campo {$attribute} {$turn_id} es inválido.");
+            }
+          },
+        ];
+      }
+    }
 
     if ($this->isMethod('PUT')) {
       $rules['description'] = "required|string|max:150|unique:presentation_combos,description,{$this->presentation_combo->id}";

--- a/app/Http/Modules/ProductCategory/ProductCategoryController.php
+++ b/app/Http/Modules/ProductCategory/ProductCategoryController.php
@@ -81,4 +81,18 @@ class ProductCategoryController extends Controller
 
     return $this->showOne($productCategory);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $productCategories = ProductCategory::select('id', 'name')
+      ->withOut('productDepartment');
+
+    return $this->showAll($productCategories, Schema::getColumnListing((new ProductCategory)->getTable()));
+  }
+
 }

--- a/app/Http/Modules/ProductCategory/ProductCategoryRequest.php
+++ b/app/Http/Modules/ProductCategory/ProductCategoryRequest.php
@@ -24,13 +24,12 @@ class ProductCategoryRequest extends FormRequest
   public function rules()
   {
     $rules = [
-      'name' => 'required|string|max:255|unique:product_categories',
-      'product_department_id'           => 'required|exists:product_departments,id'
+      'name'                  => 'required|string|max:255|unique:product_categories',
+      'product_department_id' => 'required|exists:product_departments,id'
     ];
 
     if ($this->isMethod('PUT')) {
       $rules['name'] = "required|string|max:255|unique:product_categories,name,{$this->product_category->id}";
-      $rules['product_department_id'] = "exists:product_departments,id";
     }
 
     if ($this->isMethod('GET')) {     

--- a/app/Http/Modules/ProductDepartment/ProductDepartmentController.php
+++ b/app/Http/Modules/ProductDepartment/ProductDepartmentController.php
@@ -71,4 +71,16 @@ class ProductDepartmentController extends Controller
 
     return $this->showOne($productDepartment);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $productDepartments = ProductDepartment::select('id', 'name');
+
+    return $this->showAll($productDepartments, Schema::getColumnListing((new ProductDepartment)->getTable()));
+  }
 }

--- a/app/Http/Modules/ProductSubcategory/ProductSubcategory.php
+++ b/app/Http/Modules/ProductSubcategory/ProductSubcategory.php
@@ -5,6 +5,7 @@ namespace App\Http\Modules\ProductSubcategory;
 use App\Traits\SecureDeletes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Http\Modules\ProductCategory\ProductCategory;
 
 class ProductSubcategory extends Model
 {
@@ -24,4 +25,21 @@ class ProductSubcategory extends Model
         'name',
         'product_category_id'
     ];
+
+    /**
+     * The relations to eager load on every query.
+     *
+     * @var array
+     */
+    protected $with = ['productCategory'];
+
+     /**
+     * Get the Product Category that owns the product Subcategory.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function productCategory()
+    {
+        return $this->belongsTo(ProductCategory::class);
+    }
 }

--- a/app/Http/Modules/ProductSubcategory/ProductSubcategoryController.php
+++ b/app/Http/Modules/ProductSubcategory/ProductSubcategoryController.php
@@ -69,8 +69,14 @@ class ProductSubcategoryController extends Controller
         return $this->showOne($productSubcategory);
     }
 
+    /**
+    * Display a compact list of the resource for select/combobox options.
+    *
+    * @return \Illuminate\Http\JsonResponse
+    */
     public function options(){
-        $productSubcategory = ProductSubcategory::select('id', 'name');
+        $productSubcategory = ProductSubcategory::select('id', 'name')
+            ->withOut('productCategory');
 
         return $this->showAll($productSubcategory, Schema::getColumnListing((new ProductSubcategory)->getTable()));
     }

--- a/app/Http/Modules/Region/RegionController.php
+++ b/app/Http/Modules/Region/RegionController.php
@@ -70,4 +70,18 @@ class RegionController extends Controller
 
     return $this->showOne($region);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $regions = Region::select('id', 'name')
+      ->withOut('country');
+
+    return $this->showAll($regions, Schema::getColumnListing((new Region)->getTable()));
+  }
+
 }

--- a/app/Http/Modules/SocioeconomicLevel/SocioeconomicLevelController.php
+++ b/app/Http/Modules/SocioeconomicLevel/SocioeconomicLevelController.php
@@ -72,4 +72,18 @@ class SocioeconomicLevelController extends Controller
 
     return $this->showOne($socioeconomicLevel);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $socioeconomicLevels = SocioeconomicLevel::select('id', 'name')
+      ->withOut('countries');
+
+    return $this->showAll($socioeconomicLevels, Schema::getColumnListing((new SocioeconomicLevel)->getTable()));
+  }
+
 }

--- a/app/Http/Modules/State/StateController.php
+++ b/app/Http/Modules/State/StateController.php
@@ -70,4 +70,18 @@ class StateController extends Controller
 
     return $this->showOne($state);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $states = State::select('id', 'name')
+      ->withOut('region');
+
+    return $this->showAll($states, Schema::getColumnListing((new State)->getTable()));
+  }
+
 }

--- a/app/Http/Modules/Store/Store.php
+++ b/app/Http/Modules/Store/Store.php
@@ -259,4 +259,26 @@ class Store extends Model
     {
         return $this->hasMany(Deposit::class);
     }
+
+    /**
+     * Scope a query to only include stores visibles by the user.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \App\Http\Modules\User\User $user
+     * 
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeVisible($query, User $user)
+    {
+        if ($user->role->level > 1) {
+            if ($user->role->level == 2) {
+                return $query->whereIn('id', $user->company->stores->pluck('id'));
+            } else {
+                return $query->whereIn('id', $user->stores->pluck('id'));
+            }
+
+        }
+
+        return $query;
+    }
 }

--- a/app/Http/Modules/Store/StoreRequest.php
+++ b/app/Http/Modules/Store/StoreRequest.php
@@ -66,5 +66,21 @@ class StoreRequest extends FormRequest
 
     return $rules;
   }
+
+  /**
+   * Get the validated data from the request.
+   *
+   * @return array
+   */
+  public function validated()
+  {
+    $validatedData = parent::validated();
+
+    if (auth()->user()->role->level > 1) {
+      $validatedData['company_id'] = auth()->user()->company_id;
+    }
+
+    return $validatedData;
+  }
   
 }

--- a/app/Http/Modules/StoreChain/StoreChainController.php
+++ b/app/Http/Modules/StoreChain/StoreChainController.php
@@ -70,4 +70,16 @@ class StoreChainController extends Controller
 
     return $this->showOne($storeChain);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $storeChains = StoreChain::select('id', 'name');
+
+    return $this->showAll($storeChains, Schema::getColumnListing((new StoreChain)->getTable()));
+  }
 }

--- a/app/Http/Modules/StoreFlag/StoreFlagController.php
+++ b/app/Http/Modules/StoreFlag/StoreFlagController.php
@@ -70,4 +70,17 @@ class StoreFlagController extends Controller
 
     return $this->showOne($storeFlag);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $storeFlags = StoreFlag::select('id', 'name')
+      ->withOut('storeChain');
+
+    return $this->showAll($storeFlags, Schema::getColumnListing((new StoreFlag)->getTable()));
+  }
 }

--- a/app/Http/Modules/StoreFormat/StoreFormatController.php
+++ b/app/Http/Modules/StoreFormat/StoreFormatController.php
@@ -70,4 +70,16 @@ class StoreFormatController extends Controller
 
     return $this->showOne($storeFormat);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $storeFormats = StoreFormat::select('id', 'name');
+
+    return $this->showAll($storeFormats, Schema::getColumnListing((new StoreFormat)->getTable()));
+  }
 }

--- a/app/Http/Modules/StoreTurn/StoreTurnRequest.php
+++ b/app/Http/Modules/StoreTurn/StoreTurnRequest.php
@@ -2,7 +2,8 @@
 
 namespace App\Http\Modules\StoreTurn;
 
-use Illuminate\Validation\Rule;
+use App\Http\Modules\Turn\Turn;
+use App\Http\Modules\Store\Store;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StoreTurnRequest extends FormRequest
@@ -25,12 +26,35 @@ class StoreTurnRequest extends FormRequest
     public function rules()
     {
         $rules = [
-            'store_id'                  => 'required|exists:stores,id',
-            'turn_id'                   => 'required|exists:turns,id',
-            'open_petty_cash_amount'    => 'required|min:0',
+            'open_petty_cash_amount'    => 'required|numeric|min:0',
+		    'store_id' => [
+			    'required',
+			    'integer',
+			    function ($attribute, $value, $fail) {
+				    $store = Store::where('id', $value)
+					    ->visible(auth()->user())
+					    ->first();
+
+				    if (!$store) {
+					    $fail("El campo {$attribute} es inválido.");
+				    }
+			    },
+            ],
+            'turn_id' => [
+                'required',
+                'integer',
+                function ($attribute, $value, $fail) {
+                    $turn = Turn::where('id', $value)
+                        ->where('store_id', $this->get('store_id', -1))
+                        ->visible(auth()->user())
+                        ->first();
+
+                    if (!$turn) {
+                        $fail("El campo {$attribute} es inválido.");
+                    }
+                },
+            ]
         ];
-
-
 
         if ($this->isMethod('PUT')) {
             unset($rules['open_petty_cash_amount']);

--- a/app/Http/Modules/StoreType/StoreTypeController.php
+++ b/app/Http/Modules/StoreType/StoreTypeController.php
@@ -70,4 +70,16 @@ class StoreTypeController extends Controller
 
     return $this->showOne($storeType);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $storeTypes = StoreType::select('id', 'name');
+
+    return $this->showAll($storeTypes, Schema::getColumnListing((new StoreType)->getTable()));
+  }
 }

--- a/app/Http/Modules/Turn/Turn.php
+++ b/app/Http/Modules/Turn/Turn.php
@@ -3,6 +3,7 @@
 namespace App\Http\Modules\Turn;
 
 use App\Traits\SecureDeletes;
+use App\Http\Modules\User\User;
 use App\Http\Modules\Store\Store;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -43,6 +44,28 @@ class Turn extends Model
     public function stores()
     {
         return $this->belongsToMany(Store::class, 'store_turns');
+    }
+
+    /**
+     * Scope a query to only include turns visibles by the user.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \App\Http\Modules\User\User $user
+     * 
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeVisible($query, User $user)
+    {
+        if ($user->role->level > 1) {
+            if ($user->role->level == 2) {
+                return $query->whereIn('store_id', $user->company->stores->pluck('id'));
+            } else {
+                return $query->whereIn('store_id', $user->stores->pluck('id'));
+            }
+
+        }
+
+        return $query;
     }
 
 }

--- a/app/Http/Modules/Turn/TurnController.php
+++ b/app/Http/Modules/Turn/TurnController.php
@@ -15,7 +15,7 @@ class TurnController extends Controller
    */
   public function index()
   {
-    $turns = Turn::query();
+    $turns = Turn::visible(auth()->user());
 
     return $this->showAll($turns, Schema::getColumnListing((new Turn)->getTable()));
   }
@@ -41,6 +41,8 @@ class TurnController extends Controller
    */
   public function show(Turn $turn)
   {
+    $this->authorize('manage', $turn);
+
     return $this->showOne($turn);
   }
 
@@ -53,6 +55,8 @@ class TurnController extends Controller
    */
   public function update(TurnRequest $request, Turn $turn)
   {
+    $this->authorize('manage', $turn);
+
     $turn->update($request->validated());
 
     return $this->showOne($turn);
@@ -66,6 +70,8 @@ class TurnController extends Controller
    */
   public function destroy(Turn $turn)
   {
+    $this->authorize('manage', $turn);
+    
     $turn->secureDelete();
 
     return $this->showOne($turn);

--- a/app/Http/Modules/Turn/TurnRequest.php
+++ b/app/Http/Modules/Turn/TurnRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Modules\Turn;
 
 use Illuminate\Validation\Rule;
+use App\Http\Modules\Store\Store;
 use Illuminate\Foundation\Http\FormRequest;
 
 class TurnRequest extends FormRequest
@@ -25,7 +26,6 @@ class TurnRequest extends FormRequest
   public function rules()
   {
     $rules = [
-      'store_id'   => 'required|exists:stores,id',
       'start_time' => 'required|date_format:H:i:s',
       'end_time'   => 'required|date_format:H:i:s|after:start_time',
       'is_active' =>  'required|boolean',
@@ -39,6 +39,19 @@ class TurnRequest extends FormRequest
             return $query->where('store_id', $this->get('store_id'));
           }),
       ],
+      'store_id' => [
+        'required',
+        'integer',
+        function ($attribute, $value, $fail) {
+          $store = Store::where('id', $value)
+            ->visible(auth()->user())
+            ->first();
+
+          if (!$store) {
+            $fail("El campo {$attribute} es inválido.");
+          }
+        },
+          ],
     ];
 
     if ($this->isMethod('PUT')) {

--- a/app/Http/Modules/Uom/UomController.php
+++ b/app/Http/Modules/Uom/UomController.php
@@ -70,4 +70,16 @@ class UomController extends Controller
 
     return $this->showOne($uom);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $uoms = Uom::select('id', 'name');
+
+    return $this->showAll($uoms, Schema::getColumnListing((new Uom)->getTable()));
+  }
 }

--- a/app/Http/Modules/User/AuthController.php
+++ b/app/Http/Modules/User/AuthController.php
@@ -4,11 +4,9 @@ namespace App\Http\Modules\User;
 
 use App\Support\Helper;
 use Illuminate\Http\Request;
-use Illuminate\Validation\Rule;
 use Tymon\JWTAuth\Facades\JWTAuth;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Hash;
-use Spatie\Permission\Models\Permission;
 use Illuminate\Support\Facades\Validator;
 
 class AuthController extends Controller
@@ -21,43 +19,6 @@ class AuthController extends Controller
     public function __construct()
     {
         $this->middleware('auth:api', ['except' => ['login', 'register']]);
-    }
-
-    /**
-     * Register a User.
-     * 
-     * @param \Illuminate\Http\Request $request
-     * 
-     * @return \Illuminate\Http\JsonResponse
-     */
-    public function register(Request $request)
-    {
-        $validator = Validator::make($request->all(), [
-            'name'            => 'required|string|max:100',
-            'role_id'         => 'required|exists:roles,id',
-            'email'           => 'sometimes|nullable|string|email|max:255|unique:users',
-            'username'        => 'required|string|max:100|alpha_dash|unique:users',
-            'company_id'      => 'required|exists:companies,id',
-            'password'        => 'required|string|min:8|max:25|confirmed',
-            'phone'           => [
-              'required', 
-              'digits_between:1,50',
-              Rule::unique('users', 'phone')
-                ->where(function ($query) use ($request) {
-                  return $query->where('company_id', $request->get('company_id'));
-                }),
-            ],
-        ]);
-
-        if ($validator->fails()) {
-            return $this->errorResponse(422, 'Datos inválidos', $validator->errors());
-        }
-
-        $user = User::create(array_merge($validator->validated(), [
-            'password'  => Hash::make($request->password),
-        ]));
-
-        return $this->showOne($user, 201);
     }
 
     /**

--- a/app/Http/Modules/Zone/ZoneController.php
+++ b/app/Http/Modules/Zone/ZoneController.php
@@ -70,4 +70,18 @@ class ZoneController extends Controller
 
     return $this->showOne($zone);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $zones = Zone::select('id', 'name')
+      ->withOut('municipality');
+
+    return $this->showAll($zones, Schema::getColumnListing((new Zone)->getTable()));
+  }
+
 }

--- a/app/Policies/TurnPolicy.php
+++ b/app/Policies/TurnPolicy.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Policies;
+
+use App\Http\Modules\Turn\Turn;
+use App\Http\Modules\User\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class TurnPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can manage the user.
+     *
+     * @param  \App\Http\Modules\User\User  $user
+     * @param  \App\Http\Modules\Turn\Turn  $turn
+     * 
+     * @return mixed
+     */
+    public function manage(User $user, Turn $turn)
+    {
+        if ($user->role->level > 1) {
+            if ($user->role->level == 2) {
+                return $user->company->stores->where('id', $turn->store_id)->count();
+            } else {
+                return $user->stores->where('id', $turn->store_id)->count();
+            }
+        }
+            
+        return true;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -14,6 +14,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         'App\Http\Modules\Company\Company' => 'App\Policies\CompanyPolicy',
+        'App\Http\Modules\Turn\Turn'       => 'App\Policies\TurnPolicy',
         'App\Http\Modules\User\User'       => 'App\Policies\UserPolicy',
     ];
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -116,13 +116,47 @@ Route::group(['middleware' => ['auth', 'access']], function () {
  ***********************************************************************************************************************/
 
 Route::group(['middleware' => ['auth']], function () {
-    Route::get('roles-options', 'Role\RoleController@options')->name('roles.options');
     
-    Route::get('currencies-options', 'Currency\CurrencyController@options')->name('currencies.options');
-
-    Route::get('countries-options', 'Country\CountryController@options')->name('countries.options');
+    Route::get('brands-options', 'Brand\BrandController@options')->name('brands.options');
     
     Route::get('companies-options', 'Company\CompanyController@options')->name('companies.options');
+    
+    Route::get('countries-options', 'Country\CountryController@options')->name('countries.options');
+    
+    Route::get('currencies-options', 'Currency\CurrencyController@options')->name('currencies.options');
+    
+    Route::get('location-types-options', 'LocationType\LocationTypeController@options')->name('location-types.options');
+    
+    Route::get('makers-options', 'Maker\MakerController@options')->name('makers.options');
+    
+    Route::get('municipalities-options', 'Municipality\MunicipalityController@options')->name('municipalities.options');
+    
+    Route::get('product-categories-options', 'ProductCategory\ProductCategoryController@options')->name('product-categories.options');
+    
+    Route::get('product-departments-options', 'ProductDepartment\ProductDepartmentController@options')->name('product-departments.options');
+    
+    Route::get('product-subcategories-options', 'ProductSubcategory\ProductSubcategoryController@options')->name('product-subcategories.options');
+    
+    Route::get('regions-options', 'Region\RegionController@options')->name('regions.options');
+    
+    Route::get('roles-options', 'Role\RoleController@options')->name('roles.options');
+    
+    Route::get('socioeconomic-levels-options', 'SocioeconomicLevel\SocioeconomicLevelController@options')->name('socioeconomic-levels.options');
+    
+    Route::get('states-options', 'State\StateController@options')->name('states.options');
+    
+    Route::get('store-chains-options', 'StoreChain\StoreChainController@options')->name('store-chains.options');
+    
+    Route::get('store-flags-options', 'StoreFlag\StoreFlagController@options')->name('store-flags.options');
+    
+    Route::get('store-formats-options', 'StoreFormat\StoreFormatController@options')->name('store-formats.options');
+    
+    Route::get('store-types-options', 'StoreType\StoreTypeController@options')->name('store-types.options');
+    
+    Route::get('uoms-options', 'Uom\UomController@options')->name('uoms.options');
+    
+    Route::get('zones-options', 'Zone\ZoneController@options')->name('zones.options');
+    
 });
 
 /***********************************************************************************************************************

--- a/tests/Feature/AuthControllerTest.php
+++ b/tests/Feature/AuthControllerTest.php
@@ -15,20 +15,6 @@ class AuthControllerTest extends ApiTestCase
   /**
    * @test
    */
-  public function a_guest_can_register()
-  {
-    $attributes = factory(User::class)->raw();
-    $attributes['password'] = 'password';
-    $attributes['password_confirmation'] = $attributes['password']; 
-
-    $this->postJson(route('api.register'), $attributes)
-      ->assertCreated()
-      ->assertJson(Arr::only($attributes, 'username'));
-  }
-
-  /**
-   * @test
-   */
   public function an_user_can_login()
   {
     $user = factory(User::class)->create();

--- a/tests/Feature/BrandControllerTest.php
+++ b/tests/Feature/BrandControllerTest.php
@@ -122,4 +122,24 @@ class BrandControllerTest extends ApiTestCase
     $this->assertDatabaseMissing('brands', $brand->toArray());
   }
 
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_brands_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('brands.options'))
+      ->assertOk();
+
+    $brands = Brand::select(['id', 'name'])
+      ->withOut('maker')
+      ->limit(10)
+      ->get();
+
+    foreach ($brands as $brand) {
+      $response->assertJsonFragment($brand->toArray());
+    }
+  }
+
 }

--- a/tests/Feature/LocationTypeControllerTest.php
+++ b/tests/Feature/LocationTypeControllerTest.php
@@ -122,4 +122,23 @@ class LocationTypeControllerTest extends ApiTestCase
     $this->assertDatabaseMissing('location_types', $locationType->toArray());
   }
 
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_location_types_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('location-types.options'))
+      ->assertOk();
+
+    $locationTypes = LocationType::select(['id', 'name'])
+      ->limit(10)
+      ->get();
+
+    foreach ($locationTypes as $locationType) {
+      $response->assertJsonFragment($locationType->toArray());
+    }
+  }
+
 }

--- a/tests/Feature/MakerControllerTest.php
+++ b/tests/Feature/MakerControllerTest.php
@@ -122,4 +122,23 @@ class MakerControllerTest extends ApiTestCase
     $this->assertDatabaseMissing('makers', $maker->toArray());
   }
 
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_makers_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('makers.options'))
+      ->assertOk();
+
+    $makers = Maker::select(['id', 'name'])
+      ->limit(10)
+      ->get();
+
+    foreach ($makers as $maker) {
+      $response->assertJsonFragment($maker->toArray());
+    }
+  }
+
 }

--- a/tests/Feature/MunicipalityControllerTest.php
+++ b/tests/Feature/MunicipalityControllerTest.php
@@ -122,4 +122,24 @@ class MunicipalityControllerTest extends ApiTestCase
     $this->assertDatabaseMissing('municipalities', $municipality->toArray());
   }
 
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_municipalities_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('municipalities.options'))
+      ->assertOk();
+
+    $municipalities = Municipality::select(['id', 'name'])
+      ->withOut('state')
+      ->limit(10)
+      ->get();
+
+    foreach ($municipalities as $municipality) {
+      $response->assertJsonFragment($municipality->toArray());
+    }
+  }
+
 }

--- a/tests/Feature/PresentationComboControllerTest.php
+++ b/tests/Feature/PresentationComboControllerTest.php
@@ -82,20 +82,32 @@ class PresentationComboControllerTest extends ApiTestCase
    */
   public function an_user_with_permission_can_store_a_presentation_combo()
   {
-    $this->signInWithPermissionsTo(['presentation-combos.store']);
+    $user = $this->signInWithPermissionsTo(['presentation-combos.store']);
+
+    $stores = factory(Store::class, 2)->create();
+
+    if ($user->role->level > 1) {
+      if ($user->role->level == 2) {
+        $stores->each(function ($store) use ($user) {
+          $store->update(['company_id' => $user->company_id]);
+        });
+      } else {
+        $user->stores()->sync($stores->pluck('id'));
+      }
+    }
 
     $attributes = factory(PresentationCombo::class)->raw();
     $extraAttributes['presentations'] = factory(Presentation::class, 2)->create()->pluck('id')->toArray();
     $extraAttributes['prices'] = [
       [
         'suggested_price' => 50,
-        'store_id' => factory(Store::class)->create()->id,
-        'turns' => factory(Turn::class, 2)->create()->pluck('id')->toArray(),
+        'store_id'        => $stores->first()->id,
+        'turns'           => factory(Turn::class, 2)->create(['store_id' => $stores->first()->id])->pluck('id')->toArray(),
       ],
       [
         'suggested_price' => 23,
-        'store_id' => factory(Store::class)->create()->id,
-        'turns' => factory(Turn::class, 2)->create()->pluck('id')->toArray(),
+        'store_id'        => $stores->last()->id,
+        'turns'           => factory(Turn::class, 2)->create(['store_id' => $stores->last()->id])->pluck('id')->toArray(),
       ],
     ];
 
@@ -111,7 +123,19 @@ class PresentationComboControllerTest extends ApiTestCase
    */
   public function an_user_with_permission_can_update_a_presentation_combo()
   {
-    $this->signInWithPermissionsTo(['presentation-combos.update']);
+    $user = $this->signInWithPermissionsTo(['presentation-combos.update']);
+
+    $stores = factory(Store::class, 2)->create();
+
+    if ($user->role->level > 1) {
+      if ($user->role->level == 2) {
+        $stores->each(function ($store) use ($user) {
+          $store->update(['company_id' => $user->company_id]);
+        });
+      } else {
+        $user->stores()->sync($stores->pluck('id'));
+      }
+    }
 
     $presentationCombo = factory(PresentationCombo::class)->create();
 
@@ -120,13 +144,13 @@ class PresentationComboControllerTest extends ApiTestCase
     $extraAttributes['prices'] = [
       [
         'suggested_price' => 50,
-        'store_id' => factory(Store::class)->create()->id,
-        'turns' => factory(Turn::class, 2)->create()->pluck('id')->toArray(),
+        'store_id'        => $stores->first()->id,
+        'turns'           => factory(Turn::class, 2)->create(['store_id' => $stores->first()->id])->pluck('id')->toArray(),
       ],
       [
         'suggested_price' => 23,
-        'store_id' => factory(Store::class)->create()->id,
-        'turns' => factory(Turn::class, 2)->create()->pluck('id')->toArray(),
+        'store_id'        => $stores->last()->id,
+        'turns'           => factory(Turn::class, 2)->create(['store_id' => $stores->last()->id])->pluck('id')->toArray(),
       ],
     ];
 

--- a/tests/Feature/ProductCategoryControllerTest.php
+++ b/tests/Feature/ProductCategoryControllerTest.php
@@ -121,4 +121,25 @@ class ProductCategoryControllerTest extends ApiTestCase
 
     $this->assertDatabaseMissing('product_categories', $productCategory->toArray());
   }
+
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_product_categories_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('product-categories.options'))
+      ->assertOk();
+
+    $productCategories = ProductCategory::select(['id', 'name'])
+      ->withOut('productDepartment')
+      ->limit(10)
+      ->get();
+
+    foreach ($productCategories as $productCategory) {
+      $response->assertJsonFragment($productCategory->toArray());
+    }
+  }
+
 }

--- a/tests/Feature/ProductDepartmentControllerTest.php
+++ b/tests/Feature/ProductDepartmentControllerTest.php
@@ -121,4 +121,24 @@ class ProductDepartmentControllerTest extends ApiTestCase
 
     $this->assertDatabaseMissing('product_departments', $productDepartment->toArray());
   }
+
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_product_departments_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('product-departments.options'))
+      ->assertOk();
+
+    $productDepartments = ProductDepartment::select(['id', 'name'])
+      ->withOut('productDepartment')
+      ->limit(10)
+      ->get();
+
+    foreach ($productDepartments as $productDepartment) {
+      $response->assertJsonFragment($productDepartment->toArray());
+    }
+  }
 }

--- a/tests/Feature/ProductSubcategoryControllerTest.php
+++ b/tests/Feature/ProductSubcategoryControllerTest.php
@@ -52,7 +52,7 @@ class ProductSubcategoryControllerTest extends ApiTestCase
         $this->signInWithPermissionsTo(['product-subcategories.index']);
 
         $response = $this->getJson(route('product-subcategories.index'))
-        ->assertOk();
+            ->assertOk();
         
         foreach (ProductSubcategory::limit(10)->get() as $productSubcategory) {
             $response->assertJsonFragment($productSubcategory->toArray());
@@ -69,8 +69,8 @@ class ProductSubcategoryControllerTest extends ApiTestCase
         $productSubcategory = factory(ProductSubcategory::class)->create();
 
         $this->getJson(route('product-subcategories.show', $productSubcategory->id))
-        ->assertOk()
-        ->assertJson($productSubcategory->toArray());
+            ->assertOk()
+            ->assertJson($productSubcategory->toArray());
     }
 
     /**
@@ -83,7 +83,7 @@ class ProductSubcategoryControllerTest extends ApiTestCase
         $attributes = factory(ProductSubcategory::class)->raw();
 
         $this->postJson(route('product-subcategories.store'), $attributes)
-        ->assertCreated();
+            ->assertCreated();
         
         $this->assertDatabaseHas('product_subcategories', $attributes);
     }
@@ -100,7 +100,7 @@ class ProductSubcategoryControllerTest extends ApiTestCase
         $attributes = factory(ProductSubcategory::class)->raw();
 
         $this->putJson(route('product-subcategories.update', $productSubcategory->id), $attributes)
-        ->assertOk();
+            ->assertOk();
 
         $this->assertDatabaseHas('product_subcategories', $attributes);
     }
@@ -115,8 +115,28 @@ class ProductSubcategoryControllerTest extends ApiTestCase
         $productSubcategory = factory(ProductSubcategory::class)->create();
 
         $this->deleteJson(route('product-subcategories.destroy', $productSubcategory->id))
-        ->assertOk();
+            ->assertOk();
 
         $this->assertDatabaseMissing('product_subcategories', $productSubcategory->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function an_user_can_see_all_product_subcategories_options()
+    {
+        $user = $this->signIn();
+
+        $response = $this->getJson(route('product-subcategories.options'))
+            ->assertOk();
+
+        $productSubcategories = ProductSubcategory::select(['id', 'name'])
+            ->withOut('productCategory')
+            ->limit(10)
+            ->get();
+
+        foreach ($productSubcategories as $productSubcategory) {
+            $response->assertJsonFragment($productSubcategory->toArray());
+        }
     }
 }

--- a/tests/Feature/RegionControllerTest.php
+++ b/tests/Feature/RegionControllerTest.php
@@ -121,4 +121,25 @@ class RegionControllerTest extends ApiTestCase
 
     $this->assertDatabaseMissing('regions', $region->toArray());
   }
+
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_regions_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('regions.options'))
+      ->assertOk();
+
+    $regions = Region::select(['id', 'name'])
+      ->withOut('country')
+      ->limit(10)
+      ->get();
+
+    foreach ($regions as $region) {
+      $response->assertJsonFragment($region->toArray());
+    }
+  }
+
 }

--- a/tests/Feature/SocioeconomicLevelControllerTest.php
+++ b/tests/Feature/SocioeconomicLevelControllerTest.php
@@ -122,4 +122,24 @@ class SocioeconomicLevelControllerTest extends ApiTestCase
     $this->assertDatabaseMissing('socioeconomic_levels', $socioeconomicLevel->toArray());
   }
 
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_socioeconomic_levels_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('socioeconomic-levels.options'))
+      ->assertOk();
+
+    $socioeconomicLevels = SocioeconomicLevel::select(['id', 'name'])
+      ->withOut('countries')
+      ->limit(10)
+      ->get();
+
+    foreach ($socioeconomicLevels as $socioeconomicLevel) {
+      $response->assertJsonFragment($socioeconomicLevel->toArray());
+    }
+  }
+
 }

--- a/tests/Feature/StateControllerTest.php
+++ b/tests/Feature/StateControllerTest.php
@@ -121,4 +121,25 @@ class StateControllerTest extends ApiTestCase
 
     $this->assertDatabaseMissing('states', $state->toArray());
   }
+
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_states_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('states.options'))
+      ->assertOk();
+
+    $states = State::select(['id', 'name'])
+      ->withOut('region')
+      ->limit(10)
+      ->get();
+
+    foreach ($states as $state) {
+      $response->assertJsonFragment($state->toArray());
+    }
+  }
+
 }

--- a/tests/Feature/StoreChainControllerTest.php
+++ b/tests/Feature/StoreChainControllerTest.php
@@ -123,4 +123,23 @@ class StoreChainControllerTest extends ApiTestCase
     $this->assertDatabaseMissing('store_chains', $storeChain->toArray());
   }
 
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_store_chains_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('store-chains.options'))
+      ->assertOk();
+
+    $storeChains = StoreChain::select(['id', 'name'])
+      ->limit(10)
+      ->get();
+
+    foreach ($storeChains as $storeChain) {
+      $response->assertJsonFragment($storeChain->toArray());
+    }
+  }
+
 }

--- a/tests/Feature/StoreFlagControllerTest.php
+++ b/tests/Feature/StoreFlagControllerTest.php
@@ -122,4 +122,24 @@ class StoreFlagControllerTest extends ApiTestCase
     $this->assertDatabaseMissing('store_flags', $storeFlag->toArray());
   }
 
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_store_flags_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('store-flags.options'))
+      ->assertOk();
+
+    $storeFlags = StoreFlag::select(['id', 'name'])
+      ->withOut('storeChain')
+      ->limit(10)
+      ->get();
+
+    foreach ($storeFlags as $storeFlag) {
+      $response->assertJsonFragment($storeFlag->toArray());
+    }
+  }
+
 }

--- a/tests/Feature/StoreFormatControllerTest.php
+++ b/tests/Feature/StoreFormatControllerTest.php
@@ -122,4 +122,23 @@ class StoreFormatControllerTest extends ApiTestCase
     $this->assertDatabaseMissing('store_formats', $storeFormat->toArray());
   }
 
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_store_formats_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('store-formats.options'))
+      ->assertOk();
+
+    $storeFormats = StoreFormat::select(['id', 'name'])
+      ->limit(10)
+      ->get();
+
+    foreach ($storeFormats as $storeFormat) {
+      $response->assertJsonFragment($storeFormat->toArray());
+    }
+  }
+
 }

--- a/tests/Feature/StoreTypeControllerTest.php
+++ b/tests/Feature/StoreTypeControllerTest.php
@@ -121,4 +121,23 @@ class StoreTypeControllerTest extends ApiTestCase
 
     $this->assertDatabaseMissing('store_types', $storeType->toArray());
   }
+
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_store_types_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('store-types.options'))
+      ->assertOk();
+
+    $storeTypes = StoreType::select(['id', 'name'])
+      ->limit(10)
+      ->get();
+
+    foreach ($storeTypes as $storeType) {
+      $response->assertJsonFragment($storeType->toArray());
+    }
+  }
 }

--- a/tests/Feature/UomControllerTest.php
+++ b/tests/Feature/UomControllerTest.php
@@ -121,4 +121,23 @@ class UomControllerTest extends ApiTestCase
 
     $this->assertDatabaseMissing('uoms', $uom->toArray());
   }
+
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_uoms_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('uoms.options'))
+      ->assertOk();
+
+    $uoms = Uom::select(['id', 'name'])
+      ->limit(10)
+      ->get();
+
+    foreach ($uoms as $uom) {
+      $response->assertJsonFragment($uom->toArray());
+    }
+  }
 }

--- a/tests/Feature/ZoneControllerTest.php
+++ b/tests/Feature/ZoneControllerTest.php
@@ -122,4 +122,24 @@ class ZoneControllerTest extends ApiTestCase
     $this->assertDatabaseMissing('zones', $zone->toArray());
   }
 
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_zones_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('zones.options'))
+      ->assertOk();
+
+    $zones = Zone::select(['id', 'name'])
+      ->withOut('municipality')
+      ->limit(10)
+      ->get();
+
+    foreach ($zones as $zone) {
+      $response->assertJsonFragment($zone->toArray());
+    }
+  }
+
 }


### PR DESCRIPTION
## Pull Request Description
[List Options for Store](https://app.asana.com/0/1177709353800153/1199506021694588/f)
[List Options for Products](https://app.asana.com/0/1177709353800153/1199506021694594/f)
- [x] QA @
- [ ] CR @

## What changed?
- Se desarrollaron las listas de opciones para llenar los selects/combobox al crear o editar una tienda o un producto, evitando conflictos con los permisos.
- Siguiendo con el patrón que ya se tenía de Roles, Currencies, Countries y Companies los endpoints para solicitar la lista siguen el patrón /api/{recursos}-options. Ejemplo: api/zones-options, api/brands-options...
- Se desarrollaron e implementaron las políticas de los Turnos

## Test plan
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene las carpetas Brand, LocationType, Maker, Municipality, PresentationCombo, ProductCategory, ProductDepartment, ProductSubcategory, Region, SocioeconomicLevel, State, StoreChain, StoreFlag, StoreFormat, StoreSturn, StoreType, Turn, Uom y Zone, en las cuales se encuentran las peticiones para probar los cambios mencionados.