### PR TITLE
Se desarrolló el servicio para listar las opciones de turnos

### DIFF
--- a/app/Http/Modules/Turn/TurnController.php
+++ b/app/Http/Modules/Turn/TurnController.php
@@ -77,4 +77,17 @@ class TurnController extends Controller
     return $this->showOne($turn);
   }
 
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $turns = Turn::select(['id', 'start_time', 'end_time'])
+      ->visible(auth()->user());
+
+    return $this->showAll($turns, Schema::getColumnListing((new Turn)->getTable()));
+  }
+
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -155,6 +155,8 @@ Route::group(['middleware' => ['auth']], function () {
     Route::get('store-formats-options', 'StoreFormat\StoreFormatController@options')->name('store-formats.options');
     
     Route::get('store-types-options', 'StoreType\StoreTypeController@options')->name('store-types.options');
+
+    Route::get('turns-options', 'Turn\TurnController@options')->name('turns.options');
     
     Route::get('uoms-options', 'Uom\UomController@options')->name('uoms.options');
     

--- a/tests/Feature/TurnControllerTest.php
+++ b/tests/Feature/TurnControllerTest.php
@@ -163,4 +163,24 @@ class TurnControllerTest extends ApiTestCase
 
     $this->assertDatabaseMissing('turns', $turn->toArray());
   }
+
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_turns_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('turns.options'))
+      ->assertOk();
+
+    $turns = Turn::select(['id', 'start_time', 'end_time'])
+      ->visible($user)
+      ->limit(10)
+      ->get();
+
+    foreach ($turns as $turn) {
+      $response->assertJsonFragment($turn->toArray());
+    }
+  }
 }


### PR DESCRIPTION
## Pull Request Description
[Turns Options](https://app.asana.com/0/1177709353800153/1199527985845281/f)
- [x] QA @
- [ ] CR @

## What changed?
- Se desarrolló el servicio para listar las opciones de turnos en /api/turns-options

## Test plan
- Unit Testing: `phpunit --filter TurnControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene la carpeta Turn, en la cual se encuentran las peticiones para probar los cambios mencionados.