### PR TITLE
Link de facturas a listas de ventas y listas de opciones para clientes y métodos de pago

### DIFF
--- a/app/Http/Modules/Client/ClientController.php
+++ b/app/Http/Modules/Client/ClientController.php
@@ -89,4 +89,20 @@ class ClientController extends Controller
 
     return $this->showOne($client);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $clients = Client::select('id', 'name', 'nit','address')
+      ->with(['companies' => function ($query) {
+        $query->where('id', auth()->user()->company_id);
+      }]);
+
+    return $this->showAll($clients, Schema::getColumnListing((new Client)->getTable()));
+  }
+
 }

--- a/app/Http/Modules/PaymentMethod/PaymentMethodController.php
+++ b/app/Http/Modules/PaymentMethod/PaymentMethodController.php
@@ -15,7 +15,7 @@ class PaymentMethodController extends Controller
    */
   public function index()
   {
-    $paymentMethods = PaymentMethod::query();
+    $paymentMethods = PaymentMethod::whereIn('company_id', [0, auth()->user()->company_id]);
 
     return $this->showAll($paymentMethods, Schema::getColumnListing((new PaymentMethod)->getTable()));
   }
@@ -69,5 +69,18 @@ class PaymentMethodController extends Controller
     $paymentMethod->secureDelete();
 
     return $this->showOne($paymentMethod);
+  }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $paymentMethods = PaymentMethod::select('id', 'name')
+      ->whereIn('company_id', [0, auth()->user()->company_id]);
+
+    return $this->showAll($paymentMethods, Schema::getColumnListing((new PaymentMethod)->getTable()));
   }
 }

--- a/app/Http/Modules/Sell/Sell.php
+++ b/app/Http/Modules/Sell/Sell.php
@@ -45,6 +45,7 @@ class Sell extends Model
         'seller_id',
         'status',
         'status_dte',
+        'invoice_link',
     ];
 
     /**

--- a/app/Http/Modules/Sell/SellController.php
+++ b/app/Http/Modules/Sell/SellController.php
@@ -53,8 +53,10 @@ class SellController extends Controller
       $dte = (new DTE())->fel($sell);
 
       if ($dte->certifier_success) {
-        $sell->update(['status_dte' => Sell::OPTION_STATUS_DTE_CERTIFIED]);
-        $sell->invoiceLink = config('fel.invoiceBaseUrl').$dte->uuid;
+        $sell->update([
+          'status_dte'   => Sell::OPTION_STATUS_DTE_CERTIFIED,
+          'invoice_link' => config('fel.invoiceBaseUrl').$dte->uuid,
+        ]);
       }
 
       return $this->showOne($sell, 201);
@@ -92,8 +94,10 @@ class SellController extends Controller
         $dte = (new DTE())->fel($sell);
 
         if ($dte->certifier_success) {
-          $sell->update(['status_dte' => Sell::OPTION_STATUS_DTE_CERTIFIED]);
-          $sell->invoiceLink = config('fel.invoiceBaseUrl').$dte->uuid;
+          $sell->update([
+            'status_dte' => Sell::OPTION_STATUS_DTE_CERTIFIED,
+            'invoice_link' => config('fel.invoiceBaseUrl').$dte->uuid
+          ]);
         }
 
         $sells->add($sell);
@@ -154,7 +158,10 @@ class SellController extends Controller
       $dte = (new DTE())->fel($sell, true);
 
       if ($dte->certifier_success) {
-        $sell->update(['status_dte' => Sell::OPTION_STATUS_DTE_CANCELLED]);
+        $sell->update([
+          'status_dte'   => Sell::OPTION_STATUS_DTE_CANCELLED,
+          'invoice_link' => config('fel.invoiceBaseUrl').$dte->uuid,
+        ]);
         $sell->invoiceLink = config('fel.invoiceBaseUrl').$dte->uuid;
       }
       

--- a/database/data/permissions_groups.json
+++ b/database/data/permissions_groups.json
@@ -71,12 +71,12 @@
       {
         "name": "Crear Manejo de Tiendas",
         "level": 2,
-        "routes": ["stores.store", "turns.store", "store-turns.store"]
+        "routes": ["stores.store", "turns.store"]
       },
       {
         "name": "Editar Manejo de Tiendas",
         "level": 2,
-        "routes": ["stores.update", "turns.update", "store-turns.update"]
+        "routes": ["stores.update", "turns.update"]
       },
       {
         "name": "Eliminar Manejo de Tiendas",
@@ -345,7 +345,7 @@
       {
         "name": "Crear Registro de Ventas",
         "level": 4,
-        "routes": ["sells.store", "sells-offline.store"]
+        "routes": ["sells.store", "sells-offline.store", "store-turns.store", "store-turns.update"]
       },
       {
         "name": "Editar Registro de Ventas",
@@ -439,7 +439,7 @@
     "permissions": [
       {
         "name": "Ver Manejo de Datos de Clientes",
-        "level": 3,
+        "level": 4,
         "routes": ["clients.index", "clients.show"]
       },
       {

--- a/database/factories/SellFactory.php
+++ b/database/factories/SellFactory.php
@@ -20,6 +20,7 @@ $factory->define(Sell::class, function (Faker $faker) {
         'seller_id'     => User::inRandomOrder()->first() ?? factory(User::class),
         'status'        => $faker->randomElement(Sell::getOptionsStatus()),
         'status_dte'    => $faker->randomElement(Sell::getOptionsStatusDTE()),
+        'invoice_link'  => $faker->url,
         'store_turn_id' => factory(StoreTurn::class),
     ];
 });

--- a/database/migrations/2020_06_27_000037_create_sells_table.php
+++ b/database/migrations/2020_06_27_000037_create_sells_table.php
@@ -31,6 +31,7 @@ class CreateSellsTable extends Migration
             $table->unsignedBigInteger('seller_id');
             $table->enum('status', ['PENDING', 'CANCELLED', 'PAID']);
             $table->enum('status_dte', ['NA', 'PENDING_CERTIFICATION', 'PENDING_CANCELLATION', 'CANCELLED', 'CERTIFIED']);
+            $table->string('invoice_link')->nullable();
             $table->timestamps();
             $table->softDeletes();
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -118,6 +118,8 @@ Route::group(['middleware' => ['auth', 'access']], function () {
 
 Route::group(['middleware' => ['auth']], function () {
     
+    Route::get('clients-options', 'Client\ClientController@options')->name('clients.options');
+    
     Route::get('brands-options', 'Brand\BrandController@options')->name('brands.options');
     
     Route::get('companies-options', 'Company\CompanyController@options')->name('companies.options');
@@ -131,6 +133,8 @@ Route::group(['middleware' => ['auth']], function () {
     Route::get('makers-options', 'Maker\MakerController@options')->name('makers.options');
     
     Route::get('municipalities-options', 'Municipality\MunicipalityController@options')->name('municipalities.options');
+    
+    Route::get('payment-methods-options', 'PaymentMethod\PaymentMethodController@options')->name('payment-methods.options');
     
     Route::get('product-categories-options', 'ProductCategory\ProductCategoryController@options')->name('product-categories.options');
     

--- a/tests/Feature/ClientControllerTest.php
+++ b/tests/Feature/ClientControllerTest.php
@@ -147,4 +147,25 @@ class ClientControllerTest extends ApiTestCase
 
     $this->assertDatabaseMissing('clients', $client->toArray());
   }
+
+  
+
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_clients_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('clients.options'))
+      ->assertOk();
+
+    $clients = Client::select('id', 'name', 'nit','address')
+      ->limit(10)
+      ->get();
+
+    foreach ($clients as $client) {
+      $response->assertJsonFragment($client->toArray());
+    }
+  }
 }

--- a/tests/Feature/PaymentMethodControllerTest.php
+++ b/tests/Feature/PaymentMethodControllerTest.php
@@ -50,12 +50,12 @@ class PaymentMethodControllerTest extends ApiTestCase
    */
   public function an_user_with_permission_can_see_all_payment_methods()
   {
-    $this->signInWithPermissionsTo(['payment-methods.index']);
+    $user = $this->signInWithPermissionsTo(['payment-methods.index']);
 
     $response = $this->getJson(route('payment-methods.index'))
       ->assertOk();
     
-    foreach (PaymentMethod::limit(10)->get() as $paymentMethod) {
+    foreach (PaymentMethod::whereIn('company_id', [0, $user->company_id])->limit(10)->get() as $paymentMethod) {
       $response->assertJsonFragment($paymentMethod->toArray());
     }
   }
@@ -120,6 +120,26 @@ class PaymentMethodControllerTest extends ApiTestCase
       ->assertOk();
 
     $this->assertDatabaseMissing('payment_methods', $paymentMethod->toArray());
+  }
+
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_payment_methods_options()
+  {
+    $user = $this->signIn();
+
+    $response = $this->getJson(route('payment-methods.options'))
+      ->assertOk();
+
+    $paymentMethods = PaymentMethod::select(['id', 'name'])
+      ->whereIn('company_id', [0, $user->company_id])
+      ->limit(10)
+      ->get();
+
+    foreach ($paymentMethods as $paymentMethod) {
+      $response->assertJsonFragment($paymentMethod->toArray());
+    }
   }
 
 }


### PR DESCRIPTION
## Pull Request Description
[Invoice Link to Sells](https://app.asana.com/0/1177709353800153/1199527985845281/f)
- [x] QA @
- [ ] CR @

## What changed?
- Se agregó el link de las facturas a la lista de ventas en api/sells 
- Se desarrolló el servicio para devolver la lista de opciones para clientes en /api/clients-options
- Se desarrolló el servicio para devolver la lista de opciones para métodos de pago en /api/payment-methods-options

## Test plan
- Unit Testing: `phpunit --filter SellControllerTest`
- Unit Testing: `phpunit --filter ClientControllerTest`
- Unit Testing: `phpunit --filter PaymentMethodControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene las carpetas Sell, Client y PaymentMetho, en las cuales se encuentran las peticiones para probar los cambios mencionados.