### PR TITLE
Se crea un turno por default al crear una tienda

### DIFF
--- a/app/Http/Modules/Store/StoreController.php
+++ b/app/Http/Modules/Store/StoreController.php
@@ -4,6 +4,7 @@ namespace App\Http\Modules\Store;
 
 use App\Http\Modules\Store\Store;
 use App\Http\Controllers\Controller;
+use App\Http\Modules\Turn\Turn;
 use Illuminate\Support\Facades\Schema;
 
 class StoreController extends Controller
@@ -29,6 +30,14 @@ class StoreController extends Controller
   public function store(StoreRequest $request)
   {
     $store = Store::create($request->validated());
+
+    $store->turns()->create([
+      'name'       => 'Estándar',
+      'start_time' => '08:00:00',
+      'end_time'   => '20:00:00',
+      'is_active'  => 1,
+      'is_default' => 1,
+    ]);
 
     return $this->showOne($store, 201);
   }


### PR DESCRIPTION
## Pull Request Description
[Turn Default](https://app.asana.com/0/1177709353800153/1199605717294169/f)
- [x] QA @
- [ ] CR @

## What changed?
- Al crear una tienda, automáticamente se le crea un turno "Estándar" de 8:00 am a 8:00 pm.

## Test plan
- Unit Testing: `phpunit --filter StoreControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene la carpeta Store, en la cual se encuentran las peticiones para probar los cambios mencionados.