### PR TITLE
No se puede eliminar un producto si posee una presentación activa

### DIFF
--- a/app/Http/Modules/Product/ProductController.php
+++ b/app/Http/Modules/Product/ProductController.php
@@ -64,7 +64,17 @@ class ProductController extends Controller
         }
     }
 
+    /**
+    * Remove the specified resource from storage.
+    *
+    * @param  App\Http\Modules\Product\Product  $product
+    * @return \Illuminate\Http\JsonResponse
+    */
     public function destroy(Product $product) {
+        if ($product->presentations->count()) {
+            return $this->errorResponse(409, 'El producto posee presentaciones activas');
+        }
+
         $product->secureDelete();
 
         return $this->showOne($product);


### PR DESCRIPTION
## Pull Request Description
[Destroy Product](https://app.asana.com/0/1177709353800153/1199588096420021/f)
- [x] QA @
- [ ] CR @

## What changed?
- Ya no se puede eliminar un producto si este posee una presentación activa.

## Test plan
- Unit Testing: `phpunit --filter ProductControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene la carpeta Product, en la cual se encuentran las peticiones para probar los cambios mencionados.