### PR TITLE
Se agregaron nuevos parámetros para filtrar las presentaciones y los items en venta

### DIFF
--- a/app/Http/Modules/Presentation/Presentation.php
+++ b/app/Http/Modules/Presentation/Presentation.php
@@ -7,6 +7,7 @@ use App\Http\Modules\Product\Product;
 use App\Http\Modules\Sell\SellDetail;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Http\Modules\PresentationSku\PresentationSku;
 
 class Presentation extends Model
 {
@@ -52,6 +53,36 @@ class Presentation extends Model
         return $this->hasMany(SellDetail::class);
     }
 
+    /**
+     * Get the PresentationSkus for the presentation.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\hasMany
+     */
+    public function presentationSkus()
+    {
+        return $this->hasMany(PresentationSku::class);
+    }
 
+    /**
+     * Scope a query to filter presentations by description or sku_code.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \App\Http\Modules\User\User $user
+     * 
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeFilterByDescriptionOrSkuCode($query, $description, $skuCode)
+    {
+        $query->when($description, function ($query) use ($description) {
+            $query->orWhere('description', 'ilike', $description);
+        })
+        ->when($skuCode, function ($query) use ($skuCode) {
+            $query->orWhereHas('presentationSkus', function ($subQuery) use ($skuCode) {
+                $subQuery->where('code', 'ilike', $skuCode);
+            });
+        });
+
+        return $query;
+    }
     
 }

--- a/app/Http/Modules/Presentation/PresentationController.php
+++ b/app/Http/Modules/Presentation/PresentationController.php
@@ -7,36 +7,67 @@ use Illuminate\Support\Facades\Schema;
 
 class PresentationController extends Controller
 {
+    /**
+    * Display a listing of the resource.
+    *
+    * @return \Illuminate\Http\JsonResponse
+    */
     public function index()
     {
-        $Presentations = Presentation::query();
+        $presentations = Presentation::orderBy('description')
+            ->filterByDescriptionOrSkuCode(request('presentation_description'), request('sku_code'));
 
-        return $this->showAll($Presentations, Schema::getColumnListing((new Presentation)->getTable()));
+        return $this->showAll($presentations, Schema::getColumnListing((new Presentation)->getTable()));
     }
 
+    /**
+    * Store a newly created resource in storage.
+    *
+    * @param  App\Http\Modules\Presentation\PresentationRequest  $request
+    * @return \Illuminate\Http\JsonResponse
+    */
     public function store(PresentationRequest $request)
     {
-        $Presentation = Presentation::create($request->validated());
+        $presentation = Presentation::create($request->validated());
 
-        return $this->showOne($Presentation, 201);
+        return $this->showOne($presentation, 201);
     }
     
-    public function show(Presentation $Presentation)
+    /**
+    * Display the specified resource.
+    *
+    * @param  App\Http\Modules\Presentation\Presentation  $presentation
+    * @return \Illuminate\Http\JsonResponse
+    */
+    public function show(Presentation $presentation)
     {
-        return $this->showOne($Presentation);
+        return $this->showOne($presentation);
     }
 
-    public function update(PresentationRequest $request, Presentation $Presentation)
+    /**
+    * Update the specified resource in storage.
+    *
+    * @param  App\Http\Modules\Presentation\PresentationRequest  $request
+    * @param  App\Http\Modules\Presentation\Presentation  $presentation
+    * @return \Illuminate\Http\JsonResponse
+    */
+    public function update(PresentationRequest $request, Presentation $presentation)
     {
-        $Presentation->update($request->validated());
+        $presentation->update($request->validated());
 
-        return $this->showOne($Presentation);
+        return $this->showOne($presentation);
     }
 
-    public function destroy(Presentation $Presentation)
+    /**
+    * Remove the specified resource from storage.
+    *
+    * @param  App\Http\Modules\Presentation\Presentation  $presentation
+    * @return \Illuminate\Http\JsonResponse
+    */
+    public function destroy(Presentation $presentation)
     {
-        $Presentation->secureDelete();
+        $presentation->secureDelete();
 
-        return $this->showOne($Presentation);
+        return $this->showOne($presentation);
     }
 }

--- a/database/seeds/UserSeeder.php
+++ b/database/seeds/UserSeeder.php
@@ -112,9 +112,9 @@ class UserSeeder extends Seeder
     ])->syncPermissions(Permission::all());
     
     factory(User::class)->create([
-      'name'      => 'Nelson Rodriguez',
-      'username'  => 'estuardo',
-      'email'     => 'estuardo@userlab.co',
+      'name'      => 'José González',
+      'username'  => 'jose',
+      'email'     => 'jose@userlab.co',
       'role_id'   => 1,
       ])->syncPermissions(Permission::all());
       


### PR DESCRIPTION
## Pull Request Description
[Filter by Description Or Sku code](https://app.asana.com/0/1177709353800153/1199588096420037/f)
- [x] QA @
- [x] CR @

## What changed?
- Se agregaron los parámetros "presentation_description" y "sku_code" al servicio /api/presentations, dichos parámetros se unen con un OR, no son sensibles a mayúsculas y aceptan el comodín '%'. Con estos parámetros se devolverán: 
	1. Todas las presentaciones cuya descripción coincida con "presentation_description".
	2. Todas las presentaciones que estén asociadas a un sku que coincida con el "sku_code" recibido.

- Se agregaron los parámetros "presentation_combo_description", "presentation_description" y "sku_code" al servicio /api/stores/{store_id}/turns/{turn_id}/items, dichos parámetros se unen con un OR, no son sensibles a mayúsculas y aceptan el comodín '%'. Con estos parámetros se devolverán: 
	1. Todas las presentaciones cuya descripción coincida con "presentation_description".
	2. Todas las presentaciones que estén asociadas a un sku que coincida con el "sku_code" recibido.
	3. Todos los combos cuya descripción coincida con "presentation_combo_description".
	4. Todos los combos que incluyan a las presentaciones del punto 1.
	5. Todos los combos que incluyan a las presentaciones del punto 2.
 
## Test plan
- Unit Testing: `phpunit --filter PresentationControllerTest`
- Unit Testing: `phpunit --filter StoreTurnItemControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene las carpetas Presentation y StoreTurnItem, en las cuales se encuentran las peticiones para probar los cambios mencionados.
