### PR TITLE
Cambió el nivel de permiso para listar el efectivo de las tiendas

### DIFF
--- a/database/data/permissions_groups.json
+++ b/database/data/permissions_groups.json
@@ -385,7 +385,7 @@
     "permissions": [
       {
         "name": "Ver Ajuste de Efectivo",
-        "level": 3,
+        "level": 4,
         "routes": ["stores-cash.index"]
       },
       {


### PR DESCRIPTION
## Pull Request Description
[Store Cash Permission]()
- [x] QA @
- [ ] CR @

## What changed?
- Se cambió el nivel de permiso necesario para listar el efectivo de las tiendas.

## Test plan
- Unit Testing: `phpunit --filter StoreCashControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene la carpeta StoreCash, en la cual se encuentran la petición para probar el cambio.