### PR TITLE
Remove Combos fields and Refactor on test and seeder

### DIFF
--- a/app/Http/Middleware/AccessMiddleware.php
+++ b/app/Http/Middleware/AccessMiddleware.php
@@ -19,8 +19,8 @@ class AccessMiddleware
         $user = $request->user();
         $routeName = $request->route()->getName();
         $permissions = Permission::select('permissions.*')
-            ->join('permission_route', 'permissions.id', '=', 'permission_route.permission_id')
-            ->where('permission_route.route', $routeName)
+            ->join('permission_routes', 'permissions.id', '=', 'permission_routes.permission_id')
+            ->where('permission_routes.route', $routeName)
             ->get();
 
         if ($user->hasRole(config('app.role_super_admin_name')) || ($permissions->count() && $user->hasAnyPermission($permissions))) {

--- a/app/Http/Modules/PresentationCombo/PresentationCombo.php
+++ b/app/Http/Modules/PresentationCombo/PresentationCombo.php
@@ -3,7 +3,6 @@
 namespace App\Http\Modules\PresentationCombo;
 
 use Illuminate\Support\Arr;
-use App\Http\Modules\Uom\Uom;
 use App\Traits\SecureDeletes;
 use Illuminate\Support\Facades\DB;
 use App\Http\Modules\Sell\SellDetail;
@@ -22,8 +21,6 @@ class PresentationCombo extends Model
      */
     protected $fillable = [
         'description',
-        'uom_id',
-        'minimal_expresion',
         'suggested_price',
     ];
 
@@ -32,17 +29,7 @@ class PresentationCombo extends Model
      *
      * @var array
      */
-    protected $with = ['uom', 'presentations'];
-
-    /**
-     * Get the uom that owns the presentation_combo.
-     * 
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-     */
-    public function uom()
-    {
-        return $this->belongsTo(Uom::class);
-    }
+    protected $with = ['presentations'];
 
     /**
      * The presentations that belong to the presentation_combo.

--- a/app/Http/Modules/PresentationCombo/PresentationComboRequest.php
+++ b/app/Http/Modules/PresentationCombo/PresentationComboRequest.php
@@ -26,8 +26,6 @@ class PresentationComboRequest extends FormRequest
   {
     $rules = [
       'description'              => 'required|string|max:255|unique:presentation_combos',
-      'uom_id'                   => 'required|exists:uoms,id',
-      'minimal_expresion'        => 'required|string|max:255',
       'suggested_price'          => 'required|numeric|min:0',
       'presentations'            => 'required|array',
       'presentations.*'          => 'exists:presentations,id',

--- a/database/factories/PresentationComboFactory.php
+++ b/database/factories/PresentationComboFactory.php
@@ -10,8 +10,6 @@ $factory->define(PresentationCombo::class, function (Faker $faker) {
 
     return [
         'description'       => $faker->unique()->sentence,
-        'uom_id'            => Uom::inRandomOrder()->first() ?? factory(Uom::class),
-        'minimal_expresion' => $faker->sentence,
         'suggested_price'   => rand(1, 50) * 100,
     ];
 });

--- a/database/migrations/2020_06_05_185928_create_permission_tables.php
+++ b/database/migrations/2020_06_05_185928_create_permission_tables.php
@@ -29,7 +29,7 @@ class CreatePermissionTables extends Migration
             $table->timestamps();
         });
 
-        Schema::create('permission_route', function (Blueprint $table) use ($tableNames) {
+        Schema::create('permission_routes', function (Blueprint $table) use ($tableNames) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('permission_id');
             $table->string('route');
@@ -121,7 +121,7 @@ class CreatePermissionTables extends Migration
         Schema::drop($tableNames['model_has_roles']);
         Schema::drop($tableNames['model_has_permissions']);
         Schema::drop($tableNames['roles']);
-        Schema::drop('permission_route');
+        Schema::drop('permission_routes');
         Schema::drop($tableNames['permissions']);
     }
 }

--- a/database/migrations/2020_06_27_000045_create_presentation_combos_table .php
+++ b/database/migrations/2020_06_27_000045_create_presentation_combos_table .php
@@ -23,13 +23,10 @@ class CreatePresentationCombosTable extends Migration
         Schema::create($this->tableName, function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->text('description');
-            $table->unsignedBigInteger('uom_id');
-            $table->text('minimal_expresion');
             $table->double('suggested_price');
             $table->timestamps();
             $table->softDeletes();
 
-            $table->foreign('uom_id')->references('id')->on('uoms');
         });
     }
 

--- a/database/seeds/PermissionSeeder.php
+++ b/database/seeds/PermissionSeeder.php
@@ -16,26 +16,48 @@ class PermissionSeeder extends Seeder
   {
     app()['cache']->forget('spatie.permission.cache');
 
+    $permissionsToCreate = [];
+    $permissionRoutesToCreate = [];
+
+    $nextId = DB::getDefaultConnection() == 'pgsql' ? DB::select("select nextval('permissions_id_seq')")[0]->nextval : 1;
+
     $json = File::get("database/data/permissions_groups.json");
     $permissionsGroups = json_decode($json);
     foreach ($permissionsGroups as $permissionGroup) {
       foreach ($permissionGroup->permissions as $permission) {
-        $permissionCreated = Permission::create([
-          'name'  => $permission->name,
-          'level' => $permission->level,
-          'group' => $permissionGroup->name
-        ]);
+        $permissionsToCreate[] = [
+          'id'         => $nextId,
+          'name'       => $permission->name,
+          'level'      => $permission->level,
+          'group'      => $permissionGroup->name,
+          'guard_name' => 'api',
+          'created_at' => now(),
+          'updated_at' => now(),
+        ];
 
         foreach ($permission->routes as $route) {
-          DB::table('permission_route')
-            ->insert([
-              'permission_id' => $permissionCreated->id,
-              'route'         => $route,
-              'created_at'    => now(),
-              'updated_at'    => now(),
-            ]);
+          $permissionRoutesToCreate[] = [
+            'permission_id' => $nextId,
+            'route'         => $route,
+            'created_at'    => now(),
+            'updated_at'    => now(),
+          ];
         }
+
+        $nextId++;
+
       }
     }
+
+    Permission::insert($permissionsToCreate);
+    
+    DB::table('permission_routes')
+      ->insert($permissionRoutesToCreate);
+
+    if (DB::getDefaultConnection() == 'pgsql') {
+      DB::select("select setval('permissions_id_seq', $nextId)");
+    }
+    
   }
+
 }

--- a/tests/ApiTestCase.php
+++ b/tests/ApiTestCase.php
@@ -42,8 +42,8 @@ abstract class ApiTestCase extends BaseTestCase
     {
         $user = $user ?: factory(User::class)->create();
         $permissions = Permission::select('permissions.*')
-            ->join('permission_route', 'permissions.id', '=', 'permission_route.permission_id')
-            ->whereIn('permission_route.route', $routes)
+            ->join('permission_routes', 'permissions.id', '=', 'permission_routes.permission_id')
+            ->whereIn('permission_routes.route', $routes)
             ->get();
 
         $user->givePermissionTo($permissions);

--- a/tests/Feature/PaymentMethodControllerTest.php
+++ b/tests/Feature/PaymentMethodControllerTest.php
@@ -14,7 +14,7 @@ class PaymentMethodControllerTest extends ApiTestCase
   {
     parent::setUp();
 
-    $this->seed(['PermissionSeeder', 'RoleSeeder', 'UserSeeder', 'PaymentMethodSeeder']);
+    $this->seed(['PermissionSeeder']);
   }
 
   /**
@@ -36,7 +36,7 @@ class PaymentMethodControllerTest extends ApiTestCase
   {
     $this->signIn();
     
-    $randomPaymentMethodId = PaymentMethod::all()->random()->id;
+    $randomPaymentMethodId = factory(PaymentMethod::class)->create()->id;
 
     $this->getJson(route('payment-methods.index'))->assertForbidden();
     $this->getJson(route('payment-methods.show', $randomPaymentMethodId))->assertForbidden();

--- a/tests/Feature/SellControllerTest.php
+++ b/tests/Feature/SellControllerTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature;
 use Tests\ApiTestCase;
 use App\Http\Modules\Sell\Sell;
 use Illuminate\Support\Facades\DB;
-use App\Http\Modules\Client\Client;
 use App\Http\Modules\Sell\SellInvoice;
 use App\Http\Modules\StoreTurn\StoreTurn;
 use App\Http\Modules\SellPayment\SellPayment;
@@ -22,7 +21,7 @@ class SellControllerTest extends ApiTestCase
   {
     parent::setUp();
 
-    $this->seed(['PermissionSeeder', 'RoleSeeder', 'UserSeeder', 'ClientSeeder', 'SellSeeder']);
+    $this->seed(['PermissionSeeder', 'SellSeeder']);
   }
 
   /**
@@ -130,8 +129,6 @@ class SellControllerTest extends ApiTestCase
         'price'           => 2.5,
       ]);
 
-    $client = Client::first();
-
     $attributes = [
       'store_id'          => $storeTurn->store_id,
       'payment_method_id' => factory(PaymentMethod::class)->create()->id,
@@ -198,8 +195,6 @@ class SellControllerTest extends ApiTestCase
     $combo = factory(PresentationCombo::class)->create(['suggested_price' => 5.25]);
 
     $combo->presentations()->sync([$presentationA->id, $presentationB->id]);
-
-    $client = Client::first();
 
     DB::table('turns_products')
       ->insert([

--- a/tests/Feature/SellPaymentControllerTest.php
+++ b/tests/Feature/SellPaymentControllerTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature;
 use App\Http\Modules\PaymentMethod\PaymentMethod;
 use Tests\ApiTestCase;
 use App\Http\Modules\Sell\Sell;
-use App\Http\Modules\StoreTurn\StoreTurn;
 use App\Http\Modules\SellPayment\SellPayment;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use App\Http\Modules\Company\Company;
 use Tests\ApiTestCase;
 use App\Http\Modules\User\User;
 use App\Http\Modules\Store\Store;
@@ -16,7 +15,7 @@ class UserControllerTest extends ApiTestCase
   {
     parent::setUp();
 
-    $this->seed(['PermissionSeeder', 'RoleSeeder', 'CompanySeeder', 'UserSeeder']);
+    $this->seed(['PermissionSeeder']);
   }
 
   /**

--- a/tests/Feature/UserPermissionControllerTest.php
+++ b/tests/Feature/UserPermissionControllerTest.php
@@ -15,7 +15,7 @@ class UserPermissionControllerTest extends ApiTestCase
     {
         parent::setUp();
 
-        $this->seed(['PermissionSeeder', 'RoleSeeder', 'CompanySeeder', 'UserSeeder']);
+        $this->seed(['PermissionSeeder']);
     }
 
     /**
@@ -23,7 +23,7 @@ class UserPermissionControllerTest extends ApiTestCase
      */
     public function a_guest_cannot_access_to_user_permission_resources()
     {
-        $randomUserId = User::all()->random()->id;
+        $randomUserId = factory(User::class)->create()->id;
 
         $this->getJson(route('users.permissions.index', $randomUserId))->assertUnauthorized();
         $this->postJson(route('users.permissions.store', $randomUserId))->assertUnauthorized();


### PR DESCRIPTION
## Pull Request Description
[Remove Combos fields](https://app.asana.com/0/1177709353800153/1199614588790011/f)
- [x] QA @
- [ ] CR @

## What changed?
- Se eliminaron los campos "uom_id" y "minimal_expresion" de la tabla presentation_combos.
- Se usa inserción masiva en el seeder de permisos
- Se eliminaron seeders innecesarios en algunos tests

## Test plan
- Unit Testing: `phpunit --filter PresentationComboControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene la carpeta PresentationCombo, en la cual se encuentran las peticiones para probar los cambios mencioanados.