### PR TITLE
Providers options and StoreTurns amounts

### DIFF
--- a/app/Http/Modules/Provider/ProviderController.php
+++ b/app/Http/Modules/Provider/ProviderController.php
@@ -70,4 +70,17 @@ class ProviderController extends Controller
 
     return $this->showOne($provider);
   }
+
+  /**
+   * Display a compact list of the resource for select/combobox options.
+   *
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function options()
+  {
+    $providers = Provider::select('id', 'name')
+      ->withOut('country');
+
+    return $this->showAll($providers, Schema::getColumnListing((new Provider)->getTable()));
+  }
 }

--- a/app/Http/Modules/StoreTurn/StoreTurnController.php
+++ b/app/Http/Modules/StoreTurn/StoreTurnController.php
@@ -2,14 +2,9 @@
 
 namespace App\Http\Modules\StoreTurn;
 
-use App\Http\Modules\Sell\Sell;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Schema;
-use App\Http\Modules\Purchase\Purchase;
 use App\Http\Modules\StoreTurn\StoreTurn;
-use App\Http\Modules\SellPayment\SellPayment;
-use App\Http\Modules\PaymentMethod\PaymentMethod;
-use App\Http\Modules\CashAdjustment\CashAdjustment;
 
 class StoreTurnController extends Controller
 {
@@ -48,6 +43,9 @@ class StoreTurnController extends Controller
     {
         $this->authorize('manage', $storeTurn);
 
+        $storeTurn->loadAmounts()
+            ->unsetRelations();
+
         return $this->showOne($storeTurn);
     }
 
@@ -67,48 +65,8 @@ class StoreTurnController extends Controller
         $storeTurn->store->petty_cash_amount -= $storeTurn->expenses_in_not_purchases;
         $storeTurn->store->save();
 
-        $storeTurn->card_sales_pos = $storeTurn->sellPayments()
-            ->where('status', SellPayment::OPTION_STATUS_VERIFIED)
-            ->where('payment_method_id', PaymentMethod::where('name', PaymentMethod::OPTION_PAYMENT_CARD)->first()->id)
-            ->pluck('amount')
-            ->sum();
-
-        $storeTurn->expenses_in_purchases = Purchase::where('store_id', $storeTurn->store_id)
-            ->where('payment_method_id', PaymentMethod::where('name', PaymentMethod::OPTION_PAYMENT_CASH)->first()->id)
-            ->whereBetween('date', [$storeTurn->open_date, $storeTurn->close_date])
-            ->pluck('total')
-            ->sum();
-
-        $storeTurn->deposits_total = $storeTurn->deposits
-            ->pluck('amount')
-            ->sum();
-        
-        $storeTurn->cash_sales = $storeTurn->sellPayments()
-            ->where('status', SellPayment::OPTION_STATUS_VERIFIED)
-            ->where('payment_method_id', PaymentMethod::where('name', PaymentMethod::OPTION_PAYMENT_CASH)->first()->id)
-            ->whereHas('sell', function ($query) {
-                $query->where('status', Sell::OPTION_STATUS_PAID)
-                    ->where('is_to_collect', false);
-            })
-            ->pluck('amount')
-            ->sum();
-
-        $storeTurn->cash_collected_in_receivables = $storeTurn->sellPayments()
-            ->where('status', SellPayment::OPTION_STATUS_VERIFIED)
-            ->where('payment_method_id', PaymentMethod::where('name', PaymentMethod::OPTION_PAYMENT_CASH)->first()->id)
-            ->whereHas('sell', function ($query) {
-                $query->where('status', Sell::OPTION_STATUS_PAID)
-                    ->where('is_to_collect', true);
-            })
-            ->pluck('amount')
-            ->sum();
-
-        $storeTurn->cash_adjustments_total = CashAdjustment::where('store_id', $storeTurn->store_id)
-            ->whereBetween('created_at', [$storeTurn->open_date, $storeTurn->close_date])
-            ->pluck('amount')
-            ->sum();
-
-        $storeTurn->unsetRelations();
+        $storeTurn->loadAmounts()
+            ->unsetRelations();
         
         return $this->showOne($storeTurn, 200);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -116,9 +116,9 @@ Route::group(['middleware' => ['auth', 'access']], function () {
 
 Route::group(['middleware' => ['auth']], function () {
     
-    Route::get('clients-options', 'Client\ClientController@options')->name('clients.options');
-    
     Route::get('brands-options', 'Brand\BrandController@options')->name('brands.options');
+    
+    Route::get('clients-options', 'Client\ClientController@options')->name('clients.options');
     
     Route::get('companies-options', 'Company\CompanyController@options')->name('companies.options');
     
@@ -139,6 +139,8 @@ Route::group(['middleware' => ['auth']], function () {
     Route::get('product-departments-options', 'ProductDepartment\ProductDepartmentController@options')->name('product-departments.options');
     
     Route::get('product-subcategories-options', 'ProductSubcategory\ProductSubcategoryController@options')->name('product-subcategories.options');
+    
+    Route::get('providers-options', 'Provider\ProviderController@options')->name('providers.options');
     
     Route::get('regions-options', 'Region\RegionController@options')->name('regions.options');
     

--- a/tests/Feature/ProviderControllerTest.php
+++ b/tests/Feature/ProviderControllerTest.php
@@ -121,4 +121,25 @@ class ProviderControllerTest extends ApiTestCase
 
     $this->assertDatabaseMissing('providers', $provider->toArray());
   }
+
+  /**
+   * @test
+   */
+  public function an_user_can_see_all_providers_options()
+  {
+    $this->signIn();
+
+    $response = $this->getJson(route('providers.options'))
+      ->assertOk();
+
+    $providers = Provider::select(['id', 'name'])
+      ->withOut('country')
+      ->limit(10)
+      ->get();
+
+    foreach ($providers as $provider) {
+      $response->assertJsonFragment($provider->toArray());
+    }
+  }
+
 }

--- a/tests/Feature/StoreTurnControllerTest.php
+++ b/tests/Feature/StoreTurnControllerTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use App\Http\Modules\PaymentMethod\PaymentMethod;
-use App\Http\Modules\Store\Store;
 use Tests\ApiTestCase;
 use App\Http\Modules\Turn\Turn;
 use App\Http\Modules\StoreTurn\StoreTurn;
@@ -68,6 +67,9 @@ class StoreTurnControllerTest extends ApiTestCase
      */
     public function an_user_with_permission_can_see_a_store_turn()
     {
+        factory(PaymentMethod::class)->create(['name' => PaymentMethod::OPTION_PAYMENT_CARD,]);
+        factory(PaymentMethod::class)->create(['name' => PaymentMethod::OPTION_PAYMENT_CASH,]);
+
         $user = $this->signInWithPermissionsTo(['store-turns.show']);
 
         $storeTurn = factory(StoreTurn::class)->create();


### PR DESCRIPTION
## Pull Request Description
[Providers Options](https://app.asana.com/0/1177709353800153/1199624089038650/f)
- [x] QA @
- [ ] CR @

## What changed?
- Se creó el servicio GET /api/providers-options para llenar los selects de proveedores.
- Se agregaron los montos actuales del turno en el servicio GET /api/store-turns/{store_turn_id}.

## Test plan
- Unit Testing: `phpunit --filter ProviderControllerTest`
- Unit Testing: `phpunit --filter StoreTurnControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene las carpetas Provider y StoreTurn, en las cuales se encuentran las peticiones para probar los cambios mencionados.