### PR TITLE
Fix Presentations and Combos filters

### DIFF
--- a/app/Http/Modules/Presentation/Presentation.php
+++ b/app/Http/Modules/Presentation/Presentation.php
@@ -97,14 +97,19 @@ class Presentation extends Model
      */
     public function scopeFilterByDescriptionOrSkuCode($query, $description, $skuCode)
     {
-        $query->when($description, function ($query) use ($description) {
-            $query->orWhere('description', 'ilike', $description);
-        })
-        ->when($skuCode, function ($query) use ($skuCode) {
-            $query->orWhereHas('presentationSkus', function ($subQuery) use ($skuCode) {
-                $subQuery->where('code', 'ilike', $skuCode);
+        $query->when($description, function ($query) use ($description, $skuCode) {
+            $query->where('description', 'ilike', $description)
+                ->when($skuCode, function ($query) use ($skuCode) {
+                    $query->orWhereHas('presentationSkus', function ($subQuery) use ($skuCode) {
+                        $subQuery->where('code', 'ilike', $skuCode);
+                    });
+                });
+            })
+            ->when($skuCode && !$description, function ($query) use ($skuCode) {
+                $query->whereHas('presentationSkus', function ($subQuery) use ($skuCode) {
+                    $subQuery->where('code', 'ilike', $skuCode);
+                });
             });
-        });
 
         return $query;
     }

--- a/app/Http/Modules/Presentation/PresentationTurnRequest.php
+++ b/app/Http/Modules/Presentation/PresentationTurnRequest.php
@@ -31,8 +31,8 @@ class PresentationTurnRequest extends FormRequest
 
     $rules = [
       'apply_for_all'       => 'required|integer|in:0,1',
-      'global_price'        => 'required_if:apply_all,1|numeric|min:0',
-      'prices'              => 'required_if:apply_all,0|array',
+      'global_price'        => 'required_if:apply_for_all,1|numeric|min:0',
+      'prices'              => 'required_if:apply_for_all,0|array',
       'prices.*.price'      => 'required|numeric|min:0',
       'prices.*.turns'      => 'required|array',
       'prices.*.turns.*.id' => "required|integer|distinct|in:{$this->allowedTurns->join(',')}",
@@ -72,7 +72,7 @@ class PresentationTurnRequest extends FormRequest
         ];
       }
     } else {
-      foreach ($this->get('prices') as $price) {
+      foreach ($this->get('prices', []) as $price) {
         foreach ($price['turns'] as $turn) {
           $turnsPrices[] = [
             'id'    => $turn['id'],

--- a/app/Http/Modules/PresentationCombo/PresentationComboController.php
+++ b/app/Http/Modules/PresentationCombo/PresentationComboController.php
@@ -22,7 +22,8 @@ class PresentationComboController extends Controller
       ->with('company:id,name')
       ->with('presentations:id,description')
       ->with('presentationCombosStoresTurns.store:id,name')
-      ->with('presentationCombosStoresTurns.turn');
+      ->with('presentationCombosStoresTurns.turn')
+      ->filterByDescriptionPresentationOrSku(request('presentation_combo_description'), request('presentation_description'), request('sku_code'));
 
     return $this->showAll($presentationCombos, Schema::getColumnListing((new PresentationCombo)->getTable()));
   }


### PR DESCRIPTION
## Pull Request Description
[Presentations and Combos filters](https://app.asana.com/0/1177709353800153/1199636248007431/f)
- [x] QA @
- [ ] CR @

## What changed?
- Se corrigieron los filtros de presentaciones y combos para mostrar sólo los ítems del catálogo central o empresa del usuario.

## Test plan
- Unit Testing: `phpunit --filter PresentationControllerTest`
- Unit Testing: `phpunit --filter PresentationComboControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene las carpetas Presentation y PresentationCombo, en las cuales se encuentran las peticiones para probar los cambios mencionados.