### PR TITLE
Validación de Combos multiempresas

### DIFF
--- a/app/Http/Modules/PresentationCombo/PresentationComboRequest.php
+++ b/app/Http/Modules/PresentationCombo/PresentationComboRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Modules\PresentationCombo;
 use App\Http\Modules\Turn\Turn;
 use Illuminate\Validation\Rule;
 use Illuminate\Foundation\Http\FormRequest;
+use App\Http\Modules\Presentation\Presentation;
 
 class PresentationComboRequest extends FormRequest
 {
@@ -27,7 +28,7 @@ class PresentationComboRequest extends FormRequest
   {
     $rules = [
       'suggested_price'          => 'required|numeric|min:0',
-      'presentations'            => 'required|array',
+      'presentations'            => ['required','array',$this->oneCompanyRule],
       'presentations.*'          => 'integer|visible_through_company:presentations',
       'prices'                   => 'required|array',
       'prices.*.suggested_price' => 'required|numeric|min:0',
@@ -76,6 +77,20 @@ class PresentationComboRequest extends FormRequest
     }
 
     return $validatedData;
+  }
+
+  private function oneCompanyRule($attribute, $value, $fail)
+  {
+    $companies = Presentation::query()
+      ->whereIn('id', collect($value))
+      ->whereNotIn('company_id', [0])
+      ->pluck('company_id')
+      ->unique()
+      ->count();
+    
+    if ($companies > 1) {
+      $fail("El campo {$attribute} contiene presentaciones de múltiples empresas.");
+    }
   }
   
 }

--- a/tests/Feature/PresentationComboControllerTest.php
+++ b/tests/Feature/PresentationComboControllerTest.php
@@ -99,7 +99,7 @@ class PresentationComboControllerTest extends ApiTestCase
     }
 
     $attributes = factory(PresentationCombo::class)->raw(['company_id' => $user->company_id]);
-    $extraAttributes['presentations'] = factory(Presentation::class, 2)->create()->pluck('id')->toArray();
+    $extraAttributes['presentations'] = factory(Presentation::class, 2)->create(['company_id' => $user->company_id])->pluck('id')->toArray();
     $extraAttributes['prices'] = [
       [
         'suggested_price' => 50,
@@ -139,10 +139,10 @@ class PresentationComboControllerTest extends ApiTestCase
       }
     }
 
-    $presentationCombo = factory(PresentationCombo::class)->create();
+    $presentationCombo = factory(PresentationCombo::class)->create(['company_id' => $user->company_id]);
 
     $attributes = factory(PresentationCombo::class)->raw(['company_id' => $presentationCombo->company_id]);
-    $extraAttributes['presentations'] = factory(Presentation::class, 2)->create()->pluck('id')->toArray();
+    $extraAttributes['presentations'] = factory(Presentation::class, 2)->create(['company_id' => $user->company_id])->pluck('id')->toArray();
     $extraAttributes['prices'] = [
       [
         'suggested_price' => 50,
@@ -167,9 +167,9 @@ class PresentationComboControllerTest extends ApiTestCase
    */
   public function an_user_with_permission_can_destroy_a_presentation_combo()
   {
-    $this->signInWithPermissionsTo(['presentation-combos.destroy']);
+    $user = $this->signInWithPermissionsTo(['presentation-combos.destroy']);
 
-    $presentationCombo = factory(PresentationCombo::class)->create();
+    $presentationCombo = factory(PresentationCombo::class)->create(['company_id' => $user->company_id]);
 
     $this->deleteJson(route('presentation-combos.destroy', $presentationCombo->id))
       ->assertOk();


### PR DESCRIPTION
## Pull Request Description
[Combos Multiempresas](https://app.asana.com/0/1177709353800153/1199680894845665/f)
- [x] QA @
- [ ] CR @

## What changed?
- Se validó la creación y edición de combos con presentaciones de varias empresas, solo se admiten presentaciones "propias" y/o del "catálogo central".

## Test plan
- Unit Testing: `phpunit --filter PresentationComboControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene la carpeta PresentationCombo, en la cual se encuentran las peticiones para probar los cambios mencionados.