### PR TITLE
Fix StockCount module

### DIFF
--- a/app/Http/Modules/Adjustment/Adjustment.php
+++ b/app/Http/Modules/Adjustment/Adjustment.php
@@ -83,29 +83,12 @@ class Adjustment
   
   public static function createFromStockCount(StockCount $stockCount)
   {
-    $products = [];
-
-    $stockCountsDetails = DB::table('stock_counts_detail')
-      ->where('stock_count_id', $stockCount->id)
-      ->get();
-
-    foreach ($stockCountsDetails as $stockCountDetail) {
-      
-      $stockStore = StockStore::where('store_id', $stockCount->store_id)
-        ->where('product_id', $stockCountDetail->product_id)
-        ->first();
-      
-      $diff = $stockCountDetail->quantity - $stockStore->quantity;
-
-      if ($diff) {
-        $product = [
-          'id'       => $stockCountDetail->product_id,
-          'quantity' => $stockCountDetail->quantity,
-        ];
-
-        $products[$product['id']] = $product;
-      }
-    }
+    $products = $stockCount->stockCountDetails->map(function ($stockCountDetail) {
+      return [
+        'id'       => $stockCountDetail->product_id,
+        'quantity' => $stockCountDetail->quantity,
+      ];
+    });
 
     $values = [
       'stock_count_id' => $stockCount->id,

--- a/app/Http/Modules/Purchase/PurchaseController.php
+++ b/app/Http/Modules/Purchase/PurchaseController.php
@@ -135,7 +135,7 @@ class PurchaseController extends Controller
   /**
    * Display the specified resource.
    *
-   * @param  App\Http\Modules\Purchase\Purchase  $maker
+   * @param  App\Http\Modules\Purchase\Purchase  $purchase
    * @return \Illuminate\Http\JsonResponse
    */
   public function show(Purchase $purchase)

--- a/app/Http/Modules/StockCount/StockCount.php
+++ b/app/Http/Modules/StockCount/StockCount.php
@@ -12,10 +12,15 @@ class StockCount extends Model
 {
     use SoftDeletes, SecureDeletes;
 
-    const OPTION_STATUS_OPEN   = 'OPEN';
-    const OPTION_STATUS_CLOSED = 'CLOSED';
+    const OPTION_STATUS_OPEN      = 'OPEN';
+    const OPTION_STATUS_CLOSED    = 'CLOSED';
     const OPTION_STATUS_CANCELLED = 'CANCELLED';
 
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = [
         'store_id',
         'count_date',
@@ -23,24 +28,22 @@ class StockCount extends Model
         'created_by',
     ];
 
+    /**
+     * The relations to eager load on every query.
+     *
+     * @var array
+     */
     protected $with = [
         'store',
-        'stock_counts',
+        'stockCountDetails',
         'user',
     ];
 
-    public function store() {
-        return $this->belongsTo(Store::class);
-    }
-
-    public function stock_counts() { 
-        return $this->hasMany(StockCountDetail::class, 'stock_count_id');
-    }
-
-    public function user() {
-        return $this->belongsTo(User::class, 'created_by');
-    }
-
+    /**
+    * Returns all types options availables
+    *
+    * @return array
+    */
     public static function getOptionsStatus() {
         return [
             self::OPTION_STATUS_OPEN,
@@ -49,9 +52,31 @@ class StockCount extends Model
         ];
     }
 
-    public static function getOptionStatusForUpdate() {
-        return [
-            self::OPTION_STATUS_OPEN,
-        ];
+    /**
+     * Get the store that owns the stockCount.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function store() {
+        return $this->belongsTo(Store::class);
+    }
+
+    /**
+     * Get the user that owns the stockCount.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function user() {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    /**
+     * Get the stockCountDetails for the stockCount.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\hasMany
+     */
+    public function stockCountDetails()
+    {
+        return $this->hasMany(StockCountDetail::class);
     }
 }

--- a/app/Http/Modules/StockCount/StockCountAdjustmentController.php
+++ b/app/Http/Modules/StockCount/StockCountAdjustmentController.php
@@ -16,12 +16,14 @@ class StockCountAdjustmentController extends Controller
    */
   public function store(StockCountAdjustmentRequest $request)
   {
-    $stockCount = StockCount::find($request->validated()['stock_count_id']);
+    $stockCount = StockCount::find($request->stock_count_id);
 
     $adjustmentSaved = Adjustment::createFromStockCount($stockCount);
 
     if ($adjustmentSaved) {
-      return $this->showMessage('Ajuste creado exitosamente', 201);
+      $stockCount->update(['status' => StockCount::OPTION_STATUS_CLOSED]);
+
+      return $this->showMessage('Ajuste por Conteo creado exitosamente', 201);
     } else {
       return $this->errorResponse(500, "Ha ocurrido un error interno");
     }

--- a/app/Http/Modules/StockCount/StockCountAdjustmentRequest.php
+++ b/app/Http/Modules/StockCount/StockCountAdjustmentRequest.php
@@ -26,7 +26,7 @@ class StockCountAdjustmentRequest extends FormRequest
   {
     $rules = [
       'store_id'       => 'required|integer|store_visible',
-      'stock_count_id' => "required|exists:stock_counts,id,store_id,{$this->get('store_id')},status,".StockCount::OPTION_STATUS_CLOSED.',deleted_at,NULL',
+      'stock_count_id' => "required|exists:stock_counts,id,store_id,{$this->get('store_id', 0)},status,".StockCount::OPTION_STATUS_OPEN.',deleted_at,NULL',
     ];
 
     return $rules;

--- a/app/Http/Modules/StockCount/StockCountDetail.php
+++ b/app/Http/Modules/StockCount/StockCountDetail.php
@@ -12,18 +12,36 @@ class StockCountDetail extends Model
 {
     use SoftDeletes, SecureDeletes;
 
+    /** 
+     * Table Associated with the model
+     */ 
+    protected $table = 'stock_counts_detail';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = [
         'stock_count_id',
         'product_id',
         'quantity',
     ];
 
-    protected $table = 'stock_counts_detail';
-
+    /**
+     * The relations to eager load on every query.
+     *
+     * @var array
+     */
     protected $with = [
         'product'
     ];
 
+    /**
+     * Get the product that owns the stockCountDetail.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
     public function product() {
         return $this->belongsTo(Product::class);
     }

--- a/app/Http/Modules/StockCount/StockCountRequest.php
+++ b/app/Http/Modules/StockCount/StockCountRequest.php
@@ -24,14 +24,11 @@ class StockCountRequest extends FormRequest
     public function rules()
     {
         $rules = [
-            'store_id'   => 'required|integer|store_visible',
-            'count_date' => 'required|date|date_format:Y-m-d',
-            'status'     => 'required|in:'.implode(',', StockCount::getOptionsStatus()),
+            'store_id'            => 'required|integer|store_visible',
+            'products'            => 'required|array',
+            'products.*.quantity' => 'required|numeric|min:0',
+            'products.*.id'       => "required|integer|distinct|exists:stock_stores,product_id,store_id,{$this->get('store_id')}",
         ];
-
-        if ($this->isMethod('PUT')) {
-            $rules['status'] = 'required|in:'.implode(',', StockCount::getOptionStatusForUpdate());
-        }
 
         return $rules;
     }
@@ -47,6 +44,7 @@ class StockCountRequest extends FormRequest
 
       if ($this->isMethod('POST')) {
         $validatedData['created_by'] = auth()->user()->id;
+        $validatedData['count_date'] = now()->format('Y-m-d');
       }
 
       return $validatedData;

--- a/app/Policies/ClientPolicy.php
+++ b/app/Policies/ClientPolicy.php
@@ -28,7 +28,7 @@ class ClientPolicy
     }
 
     /**
-     * Determine whether the user can manage the client.
+     * Determine whether the user can destroy the client.
      *
      * @param  \App\Http\Modules\User\User  $user
      * @param  \App\Http\Modules\Client\Client  $client

--- a/app/Policies/StockCountPolicy.php
+++ b/app/Policies/StockCountPolicy.php
@@ -30,6 +30,19 @@ class StockCountPolicy
             
         return true;
     }
+
+    /**
+     * Determine whether the user can destroy the stockCount.
+     *
+     * @param  \App\Http\Modules\User\User  $user
+     * @param  \App\Http\Modules\StockCount\StockCount  $stockCount
+     * 
+     * @return mixed
+     */
+    public function destroy(User $user, StockCount $stockCount)
+    {
+        return $stockCount->status==StockCount::OPTION_STATUS_OPEN && $this->manage($user, $stockCount);
+    }
 }
 
 

--- a/database/data/permissions_groups.json
+++ b/database/data/permissions_groups.json
@@ -298,12 +298,12 @@
       {
         "name": "Editar Conteos de Inventario",
         "level": 3,
-        "routes": ["stock-counts.update"]
+        "routes": []
       },
       {
         "name": "Eliminar Conteos de Inventario",
         "level": 3,
-        "routes": []
+        "routes": ["stock-counts.destroy"]
       }
     ]
   },

--- a/database/factories/StockCountDetailFactory.php
+++ b/database/factories/StockCountDetailFactory.php
@@ -10,7 +10,7 @@ use App\Http\Modules\StockCount\StockCountDetail;
 $factory->define(StockCountDetail::class, function (Faker $faker) {
     return [
         'stock_count_id' => factory(StockCount::class),
-        'product_id' => factory(Product::class),
-        'quantity' => 50,
+        'product_id'     => factory(Product::class),
+        'quantity'       => 50,
     ];
 });

--- a/database/factories/StockCountFactory.php
+++ b/database/factories/StockCountFactory.php
@@ -10,8 +10,8 @@ use App\Http\Modules\Store\Store;
 $factory->define(StockCount::class, function (Faker $faker) {
     return [
         'count_date' => $faker->date(),
-        'store_id' => Store::inRandomOrder()->first() ?? factory(Store::class),
-        'status' => $faker->randomElement(StockCount::getOptionsStatus()),
+        'store_id'   => Store::inRandomOrder()->first() ?? factory(Store::class),
+        'status'     => $faker->randomElement(StockCount::getOptionsStatus()),
         'created_by' => User::inRandomOrder()->first() ?? factory(User::class),
     ];
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -77,7 +77,7 @@ Route::group(['middleware' => ['auth', 'access']], function () {
 
     Route::resource('stocks', 'Stock\StockController')->only('index');
 
-    Route::resource('stock-counts', 'StockCount\StockCountController')->except('create', 'edit', 'destroy');
+    Route::resource('stock-counts', 'StockCount\StockCountController')->except('create', 'edit', 'update');
 
     Route::resource('stock-counts-adjustments', 'StockCount\StockCountAdjustmentController')->only('store');
 

--- a/tests/Feature/StockCountAdjustmentControllerTest.php
+++ b/tests/Feature/StockCountAdjustmentControllerTest.php
@@ -57,7 +57,7 @@ class StockCountAdjustmentControllerTest extends ApiTestCase
 
     $stockCount = factory(StockCount::class)->create([
       'store_id' => $store->id,
-      'status'   => StockCount::OPTION_STATUS_CLOSED,
+      'status'   => StockCount::OPTION_STATUS_OPEN,
     ]);
 
     foreach ($store->products as $product) {
@@ -75,6 +75,11 @@ class StockCountAdjustmentControllerTest extends ApiTestCase
 
     $this->postJson(route('stock-counts-adjustments.store'), $attributes)
       ->assertCreated();
+
+    $this->assertDatabaseHas('stock_counts', [
+      'id'     => $stockCount->id,
+      'status' => StockCount::OPTION_STATUS_CLOSED
+    ]);
 
     $this->assertDatabaseHas('stock_movements', [
       'store_id'    => $store->id,


### PR DESCRIPTION
## Pull Request Description
[Stock Count module](https://app.asana.com/0/1177709353800153/1200103676777100/f)
- [x] QA @
- [ ] CR @

## What changed?
- Se validaron los productos presentes en el conteo.
- Cuando se crea un conteo se guarda su detalle y su status será "OPEN".
- Cuando se cancela un conteo este debe tener un status "OPEN" y pasará a tener un status "CANCELLED".
- Cuando se genera un ajuste por conteo este debe tener un status "OPEN" y pasará a tener un status "CLOSED".
- Se eliminó el endpoint para editar un conteo.
- Se creó el endpoint DELETE /api/api/stock-counts/{conteo_id} para cancelar los conteos.


## Test plan
- Unit Testing: `phpunit --filter StockCountControllerTest`
- Unit Testing: `phpunit --filter StockCountAdjustmentControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene las carpetas StockCount y StockCountAdjustment, en las cuales se encuentran las peticiones para probar los cambios mencionados.