### PR TITLE
Allow negative quantity_stock on counts

### DIFF
--- a/app/Http/Modules/StockCount/StockCountRequest.php
+++ b/app/Http/Modules/StockCount/StockCountRequest.php
@@ -27,7 +27,7 @@ class StockCountRequest extends FormRequest
             'store_id'                  => 'required|integer|store_visible',
             'products'                  => 'required|array',
             'products.*.quantity'       => 'required|numeric|min:0',
-            'products.*.quantity_stock' => 'required|numeric|min:0',
+            'products.*.quantity_stock' => 'required|numeric',
             'products.*.id'             => "required|integer|distinct|exists:stock_stores,product_id,store_id,{$this->get('store_id')}",
         ];
 


### PR DESCRIPTION
## Pull Request Description
[Allow negative quantity_stock](https://app.asana.com/0/1177709353800153/1200103676777100/f)
- [x] QA @
- [ ] CR @

## What changed?
- Se permite enviar un valor negativo en quantity_stock en Conteos.

## Test plan
- Unit Testing: `phpunit --filter StockCountControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene la carpeta StockCount, en la cual se encuentran las peticiones para probar los cambios mencionados.