### PR TITLE
Avoid destroy presentations with active skus

### DIFF
--- a/app/Http/Modules/Presentation/PresentationController.php
+++ b/app/Http/Modules/Presentation/PresentationController.php
@@ -75,6 +75,10 @@ class PresentationController extends Controller
     {
         $this->authorize('manage', $presentation);
 
+        if ($presentation->presentationSkus->count() > 0) {
+            return $this->errorResponse(409, "La presentación tiene SKU's activos.");
+        }
+
         $presentation->secureDelete();
 
         return $this->showOne($presentation);

--- a/tests/Feature/PresentationControllerTest.php
+++ b/tests/Feature/PresentationControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use Tests\ApiTestCase;
 use App\Http\Modules\Presentation\Presentation;
+use App\Http\Modules\PresentationSku\PresentationSku;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class PresentationControllerTest extends ApiTestCase
@@ -122,6 +123,12 @@ class PresentationControllerTest extends ApiTestCase
       ->assertOk();
 
     $this->assertDatabaseMissing('presentations', $presentation->toArray());
+
+    $presentacionSku = factory(PresentationSku::class)->create();
+    $presentationWithSKU = $presentacionSku->presentation;
+
+    $this->deleteJson(route('presentations.destroy', $presentationWithSKU->id))
+      ->assertStatus(409);
   }
 
   /**


### PR DESCRIPTION
## Pull Request Description
[Avoid destroy presentation with active skus](https://app.asana.com/0/1177709353800153/1200201692405809/f)
- [x] QA @
- [ ] CR @

## What changed?
- Se impide al usuario eliminar presentaciones con skus activas.

## Test plan
- Unit Testing: `phpunit --filter PresentationControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene la carpeta Presentation, en la cual se encuentran las peticiones para probar los cambios mencionados.