### PR TITLE
Alphanumeric nit

### DIFF
--- a/app/Http/Modules/Client/ClientRequest.php
+++ b/app/Http/Modules/Client/ClientRequest.php
@@ -34,7 +34,7 @@ class ClientRequest extends FormRequest
       'birthdate'    => 'present|nullable|date|date_format:Y-m-d|before:today|after:1900-01-01',
       'phone'        => 'present|nullable|max:50',
       'email'        => 'present|nullable|email|max:100',
-      'nit'          => ['required', 'string', 'max:15', 'regex:/^\d+k?$/i',
+      'nit'          => ['required', 'string', 'alpha_num', 'max:15',
         (new IUniqueRule('clients'))
           ->where('country_id', $this->get('country_id'))
           ->ignore($this->client),

--- a/app/Http/Modules/Company/CompanyRequest.php
+++ b/app/Http/Modules/Company/CompanyRequest.php
@@ -32,7 +32,7 @@ class CompanyRequest extends FormRequest
       'address'               => 'required|string|max:255',
       'currency_id'           => 'required|integer|exists:currencies,id,deleted_at,NULL',
       'country_id'            => 'required|integer|exists:countries,id,deleted_at,NULL',
-      'nit'                   => ['required', 'string', 'max:15', 'regex:/^\d+k?$/i',
+      'nit'                   => ['required', 'string', 'alpha_num', 'max:15',
         (new IUniqueRule('companies'))
           ->where('country_id', $this->get('country_id'))
           ->ignore($this->company),

--- a/app/Http/Modules/Provider/ProviderRequest.php
+++ b/app/Http/Modules/Provider/ProviderRequest.php
@@ -33,7 +33,7 @@ class ProviderRequest extends FormRequest
           ->ignore($this->provider),
           
       ],
-      'nit'        => ['required', 'string', 'max:15', 'regex:/^\d+k?$/i',
+      'nit'        => ['required', 'string', 'alpha_num', 'max:15',
         Rule::unique('providers')
           ->where('country_id', $this->get('country_id'))
           ->ignore($this->provider),

--- a/app/Http/Modules/Sell/SellRequest.php
+++ b/app/Http/Modules/Sell/SellRequest.php
@@ -29,7 +29,7 @@ class SellRequest extends FormRequest
       'store_turn_id'      => "required|integer|exists:store_turns,id,store_id,{$this->get('store_id')},is_open,1,deleted_at,NULL",
       'payment_method_id'  => 'required|integer|visible_through_company:payment_methods',
       'name'               => 'required|string|max:250',
-      'nit'                => ['required', 'string', 'max:15', 'regex:/^\d+k?$|^cf$/i'],
+      'nit'                => 'required|string|alpha_num|max:15',
       'address'            => 'required|string|max:50',
       'phone'              => 'present|nullable|string|max:50',
       'email'              => 'present|nullable|string|email|max:100',

--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -13,7 +13,7 @@ $factory->define(Client::class, function (Faker $faker) {
         'name'         => $faker->name ,
         'type'         => $faker->randomElement(Client::getOptionsTypes()) ,
         'country_id'   => Country::inRandomOrder()->first() ?? factory(Country::class) ,
-        'nit'          => $faker->numerify('##############'),
+        'nit'          => strtoupper($faker->bothify('##??##??')),
         'address'      => $faker->address ,
         'sex'          => $faker->randomElement(Client::getOptionsSex()) ,
         'biometric_id' => Str::random(50) ,

--- a/database/factories/CompanyFactory.php
+++ b/database/factories/CompanyFactory.php
@@ -13,7 +13,7 @@ $factory->define(Company::class, function (Faker $faker) {
         'name'               => $faker->company,
         'reason'             => $faker->paragraph,
         'regime'             => $faker->sentence(2),
-        'nit'                => $faker->numerify('##############'),
+        'nit'                => strtoupper($faker->bothify('##??##??')),
         'phone'              => rand(100000,9999999),
         'address'            => $faker->address,
         'country_id'         => Country::inRandomOrder()->first() ?? factory(Country::class),

--- a/database/factories/ProviderFactory.php
+++ b/database/factories/ProviderFactory.php
@@ -10,7 +10,7 @@ $factory->define(Provider::class, function (Faker $faker) {
 
     return [
         'name'       => $faker->unique()->company,
-        'nit'        => $faker->numerify('##############'),
+        'nit'        => strtoupper($faker->bothify('##??##??')),
         'country_id' => Country::inRandomOrder()->first() ?? factory(Country::class),
     ];
 });

--- a/tests/Feature/ClientControllerTest.php
+++ b/tests/Feature/ClientControllerTest.php
@@ -173,4 +173,26 @@ class ClientControllerTest extends ApiTestCase
       $response->assertJsonFragment($client->toArray());
     }
   }
+
+  /**
+   * @test
+   */
+  public function an_user_with_permission_can_not_store_a_client_nit_with_symbols()
+  {
+    $user = $this->signInWithPermissionsTo(['clients.store']);
+
+    $attributes = factory(Client::class)->raw(['country_id' => $user->company->country_id, 'nit' => '123.123']);
+
+    $extraAttributes = [
+      'phone' => $user->phone,
+      'email' => $user->email,
+    ];
+
+    $this->postJson(route('clients.store'), array_merge($attributes, $extraAttributes))
+      ->assertStatus(422)
+      ->assertJsonValidationErrors('nit');
+  }
+
+
+
 }

--- a/tests/Feature/CompanyControllerTest.php
+++ b/tests/Feature/CompanyControllerTest.php
@@ -169,4 +169,18 @@ class CompanyControllerTest extends ApiTestCase
     }
   }
 
+  /**
+   * @test
+   */
+  public function an_user_with_permission_can_not_store_a_company_nit_with_symbols()
+  {
+    $this->signInWithPermissionsTo(['companies.store']);
+
+    $attributes = factory(Company::class)->raw(['nit' => '123-123']);
+
+    $this->postJson(route('companies.store'), $attributes)
+      ->assertStatus(422)
+      ->assertJsonValidationErrors('nit');    
+  }
+
 }

--- a/tests/Feature/ProviderControllerTest.php
+++ b/tests/Feature/ProviderControllerTest.php
@@ -142,4 +142,18 @@ class ProviderControllerTest extends ApiTestCase
     }
   }
 
+  /**
+   * @test
+   */
+  public function an_user_with_permission_can_not_store_a_provider_nit_with_symbols()
+  {
+    $this->signInWithPermissionsTo(['providers.store']);
+
+    $attributes = factory(Provider::class)->raw(['nit' => '123$123']);
+
+    $this->postJson(route('providers.store'), $attributes)
+      ->assertStatus(422)
+      ->assertJsonValidationErrors('nit');
+  }
+
 }


### PR DESCRIPTION
## Pull Request Description
[Alphanumerics nits](https://app.asana.com/0/1177709353800153/1200225121208518/f)
- [x] QA @
- [ ] CR @

## What changed?
- Ahora los nits de Clientes, Empresas y Proveedores están compuestos por caracteres alfanuméricos sin seguir ningún patrón. 

## Test plan
- Unit Testing: `phpunit --filter ClientControllerTest`
- Unit Testing: `phpunit --filter CompanyControllerTest`
- Unit Testing: `phpunit --filter ProviderControllerTest`
- Unit Testing: `phpunit --filter SellControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene las carpetas Client, Company, Provider y Sell, en las cuales se encuentran las peticiones para probar los cambios mencionados.