### PR TITLE
Duplicate Stores

### DIFF
--- a/app/Http/Modules/Store/Store.php
+++ b/app/Http/Modules/Store/Store.php
@@ -280,4 +280,31 @@ class Store extends Model
 
         return $query;
     }
+
+    /**
+     * Copy the turns, presentation price turns and combo price turns from the store given
+     *
+     * @param Store $store
+     * @return void
+     */
+    public function copyTurnsAndPricesFrom(Store $store)
+    {
+        $store->turns->each(function (Turn $turn) {
+            $turnDuplicated = $this->turns()->create($turn->toArray());
+
+            $turn->presentations->each(function ($presentation) use ($turnDuplicated) {
+
+                $presentation->turns()->attach([$turnDuplicated->id => ['price' => $presentation->pivot->price]]);
+            });
+
+            $turn->presentationCombosStoresTurns()->each(function ($presentationComboStoreTurn) use ($turnDuplicated) {
+
+                $turnDuplicated->presentationCombosStoresTurns()->create([
+                    'presentation_combo_id' => $presentationComboStoreTurn->presentation_combo_id,
+                    'store_id'              => $turnDuplicated->store_id,
+                    'suggested_price'       => $presentationComboStoreTurn->suggested_price,
+                ]);
+            });
+        });
+    }
 }

--- a/app/Http/Modules/Store/StoreDuplicateController.php
+++ b/app/Http/Modules/Store/StoreDuplicateController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Modules\Store;
+
+use Exception;
+use App\Http\Modules\Store\Store;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use App\Http\Controllers\Controller;
+
+class StoreDuplicateController extends Controller
+{
+  /**
+   * Store a newly created resource in storage.
+   *
+   * @param  App\Http\Modules\Store\StoreRequest  $request
+   * @return \Illuminate\Http\JsonResponse
+   */
+  public function store(StoreDuplicateRequest $request)
+  {
+    $this->authorize('create', Store::class);
+
+    try {
+      DB::beginTransaction();
+
+      $storeDuplicated = Store::create($request->validated());
+
+      $storeDuplicated->copyTurnsAndPricesFrom(Store::find($request->store_id));
+
+      DB::commit();
+      
+      return $this->showOne($storeDuplicated, 201);
+
+    } catch (Exception $exception) {
+      DB::rollback();
+
+      Log::error($exception);
+
+      return $this->errorResponse(500, "Ha ocurrido un error interno");
+    }
+  }
+}

--- a/app/Http/Modules/Store/StoreDuplicateRequest.php
+++ b/app/Http/Modules/Store/StoreDuplicateRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Modules\Store;
+
+
+class StoreDuplicateRequest extends StoreRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $rules = parent::rules();
+
+        $rules['store_id'] = 'required|integer|store_visible';
+
+        return $rules;
+    }
+}

--- a/app/Http/Modules/Turn/Turn.php
+++ b/app/Http/Modules/Turn/Turn.php
@@ -7,6 +7,8 @@ use App\Http\Modules\Store\Store;
 use App\Traits\ResourceVisibility;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Http\Modules\Presentation\Presentation;
+use App\Http\Modules\PresentationCombo\PresentationComboStoreTurn;
 
 class Turn extends Model
 {
@@ -45,5 +47,26 @@ class Turn extends Model
     {
         return $this->belongsToMany(Store::class, 'store_turns');
     }
+
+    /**
+     * The presentations that belong to the turn.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function presentations()
+    {
+        return $this->belongsToMany(Presentation::class, 'presentations_turns')->withPivot('price')->withTimestamps();
+    }
+
+    /**
+     * Get the presentationComboStoreTurn for the turn.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function presentationCombosStoresTurns()
+    {
+        return $this->hasMany(PresentationComboStoreTurn::class);
+    }
+
 
 }

--- a/database/data/permissions_groups.json
+++ b/database/data/permissions_groups.json
@@ -69,7 +69,7 @@
       {
         "name": "Crear Manejo de Tiendas",
         "level": 2,
-        "routes": ["stores.store", "turns.store"]
+        "routes": ["stores.store", "turns.store", "stores-duplicate.store"]
       },
       {
         "name": "Editar Manejo de Tiendas",

--- a/routes/api.php
+++ b/routes/api.php
@@ -83,6 +83,8 @@ Route::group(['middleware' => ['auth', 'access']], function () {
 
     Route::resource('stores', 'Store\StoreController')->except('create', 'edit');
 
+    Route::resource('stores-duplicate', 'Store\StoreDuplicateController')->only('store');
+
     Route::resource('store-chains', 'StoreChain\StoreChainController')->except('create', 'edit');
 
     Route::resource('store-flags', 'StoreFlag\StoreFlagController')->except('create', 'edit');

--- a/tests/Feature/DuplicateStoreControllerTest.php
+++ b/tests/Feature/DuplicateStoreControllerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\ApiTestCase;
+use App\Http\Modules\Turn\Turn;
+use App\Http\Modules\Store\Store;
+use App\Http\Modules\Presentation\Presentation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Http\Modules\PresentationCombo\PresentationCombo;
+use App\Http\Modules\PresentationCombo\PresentationComboStoreTurn;
+
+class DuplicateStoreControllerTest extends ApiTestCase
+{
+  use RefreshDatabase;
+
+  public function setUp(): void
+  {
+    parent::setUp();
+
+    $this->seed(['PermissionSeeder']);
+  }
+
+  /**
+   * @test
+   */
+  public function a_guest_cannot_access_to_stores_duplicate_resources()
+  {
+    $this->postJson(route('stores-duplicate.store', rand()))->assertUnauthorized();
+  }
+
+  /**
+   * @test
+   */
+  public function an_user_without_permission_cannot_access_to_stores_duplicate_resources()
+  {
+    $this->signIn();
+    
+    $this->postJson(route('stores-duplicate.store', rand()))->assertForbidden();
+  }
+
+  /**
+   * @test
+   */
+  public function an_user_with_permission_can_duplate_a_store()
+  {
+    $user = $this->signInWithPermissionsTo(['stores-duplicate.store']);
+
+    $user->company->update(['allow_add_stores' => true]);
+    $store = factory(Store::class)->create();
+
+    if ($user->role->level > 1) {
+      if ($user->role->level == 2) {
+        $store->update(['company_id' => $user->company_id]);
+      } else {
+        $user->stores()->sync($store->id);
+      }
+    }
+
+    $turns = factory(Turn::class, 2)->create(['store_id' => $store->id]);
+    $presentations = factory(Presentation::class, 2)->create();
+    $presentationCombo = factory(PresentationCombo::class)->create();
+
+    $presentations->first()->turns()->sync([$turns->first()->id => ['price'  => 100]]);
+    $presentations->last()->turns()->sync( [$turns->last()->id  => ['price'  => 400]]);
+
+    PresentationComboStoreTurn::create([
+      'presentation_combo_id' => $presentationCombo->id,
+      'store_id'              => $store->id,
+      'turn_id'               => $turns->first()->id,
+      'suggested_price'       => 500,
+    ]);
+    
+    $attributes = factory(Store::class)->raw();
+
+    $this->postJson(route('stores-duplicate.store'), array_merge($attributes, ['store_id' => $store->id]))
+      ->assertCreated();
+    
+    $this->assertDatabaseHas('stores', $attributes);
+    
+    foreach ($turns as $turn) {
+      $this->assertDatabaseHas('turns', [
+        'store_id'   => 2,
+        'name'       => $turn->name,
+        'start_time' => $turn->start_time,
+        'end_time'   => $turn->end_time,
+        'is_active'  => $turn->is_active,
+        'is_default' => $turn->is_default,
+        ]);
+      }
+      
+      $this->assertDatabaseHas('presentations_turns', [
+        'presentation_id' => $presentations->first()->id,
+        'turn_id'         => $presentations->first()->turns[1]->id,
+        'price'           => 100,
+      ]);
+
+      $this->assertDatabaseHas('presentations_turns', [
+        'presentation_id' => $presentations->last()->id,
+        'turn_id'         => $presentations->last()->turns[1]->id,
+        'price'           => 400,
+      ]);
+
+      $this->assertDatabaseHas('presentation_combos_stores_turns', [
+        'presentation_combo_id' => $presentationCombo->id,
+        'store_id'              => 2,
+        'turn_id'               => $presentationCombo->presentationCombosStoresTurns->last()->turn_id,
+        'suggested_price'       => 500,
+      ]);
+  }
+
+}


### PR DESCRIPTION
## Pull Request Description
[Duplicate Stores](https://app.asana.com/0/1177709353800153/1199699613598346/f)
- [x] QA @
- [ ] CR @

## What changed?
- Se creó el servicio POST /api/stores-duplicate para duplicar una tienda con sus turnos y precios de presentaciones y combos.

## Test plan
- Unit Testing: `phpunit --filter StoreDuplicateControllerTest`
- Unit Testing: `phpunit`
- Manual: La [colección de Postman](https://www.getpostman.com/collections/f9915eb58b7c4334e4bc) contiene la carpeta StoreDuplicate, en la cual se encuentran las peticiones para probar los cambios mencionados.